### PR TITLE
Add SRSFilter with persistence and due item retrieval

### DIFF
--- a/src/language_learning/spaced_repetition.py
+++ b/src/language_learning/spaced_repetition.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import Dict, Optional
+import json
 
 
 @dataclass
@@ -44,6 +46,101 @@ class SpacedRepetitionScheduler:
 
         self.state.next_review = datetime.now() + timedelta(days=self.state.interval)
         return self.state.next_review
+
+
+class SRSFilter:
+    """Manage multiple words and their review state.
+
+    Each word has an associated :class:`SpacedRepetitionScheduler` and a
+    ``goal_frequency_rank``.  Lower ranks indicate higher frequency.
+
+    Items can be serialised to and from JSON using :meth:`save_state` and
+    :meth:`load_state`.
+    """
+
+    def __init__(self, goal_frequency_ranks: Dict[str, int]) -> None:
+        self.goal_frequency_ranks = goal_frequency_ranks
+        self.schedulers: Dict[str, SpacedRepetitionScheduler] = {
+            word: SpacedRepetitionScheduler() for word in goal_frequency_ranks
+        }
+
+    # ------------------------------------------------------------------
+    # Persistence helpers
+    def save_state(self, path: str) -> None:
+        """Persist review state as JSON to *path*."""
+
+        data: Dict[str, Dict[str, object]] = {}
+        for word, scheduler in self.schedulers.items():
+            st = scheduler.state
+            data[word] = {
+                "repetitions": st.repetitions,
+                "interval": st.interval,
+                "efactor": st.efactor,
+                "next_review": st.next_review.isoformat(),
+                "goal_frequency_rank": self.goal_frequency_ranks.get(word, 1),
+            }
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    @classmethod
+    def load_state(cls, path: str) -> "SRSFilter":
+        """Load review state from *path* and return a new ``SRSFilter``."""
+
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        ranks = {word: int(info["goal_frequency_rank"]) for word, info in data.items()}
+        filt = cls(ranks)
+        for word, info in data.items():
+            st = filt.schedulers[word].state
+            st.repetitions = int(info["repetitions"])
+            st.interval = int(info["interval"])
+            st.efactor = float(info["efactor"])
+            st.next_review = datetime.fromisoformat(info["next_review"])
+        return filt
+
+    # ------------------------------------------------------------------
+    # Review helpers
+    def review(self, word: str, quality: int) -> datetime:
+        """Review *word* with given *quality* using its scheduler."""
+
+        return self.schedulers[word].review(quality)
+
+    def _forgetting_probability(self, word: str, now: Optional[datetime] = None) -> float:
+        """Compute a crude forgetting probability for *word*.
+
+        The value is proportional to how overdue an item is: items not yet due
+        have a probability of ``0`` while overdue items increase linearly with
+        the number of days past ``next_review``.
+        """
+
+        sched = self.schedulers[word]
+        now = now or datetime.now()
+        overdue_seconds = (now - sched.state.next_review).total_seconds()
+        if overdue_seconds <= 0:
+            return 0.0
+        interval = sched.state.interval or 1
+        return overdue_seconds / 86400 / interval
+
+    def pop_next_due(self) -> Optional[str]:
+        """Return the next due word based on priority.
+
+        Priority is calculated as ``forgetting_probability * goal_frequency``
+        where ``goal_frequency`` is the reciprocal of ``goal_frequency_rank``.
+        """
+
+        now = datetime.now()
+        best_word: Optional[str] = None
+        best_score = -1.0
+        for word in self.schedulers:
+            fp = self._forgetting_probability(word, now)
+            if fp <= 0:
+                continue
+            goal_freq = 1.0 / float(self.goal_frequency_ranks.get(word, 1))
+            score = fp * goal_freq
+            if score > best_score:
+                best_score = score
+                best_word = word
+        return best_word
 
 
 if __name__ == "__main__":  # pragma: no cover - example usage

--- a/tests/test_spaced_repetition.py
+++ b/tests/test_spaced_repetition.py
@@ -1,4 +1,6 @@
-from language_learning.spaced_repetition import SpacedRepetitionScheduler
+from datetime import datetime, timedelta
+
+from language_learning.spaced_repetition import SRSFilter, SpacedRepetitionScheduler
 
 
 def test_review_progress():
@@ -8,3 +10,30 @@ def test_review_progress():
     assert scheduler.state.repetitions == 2
     assert scheduler.state.interval >= 1
     assert second > first
+
+
+def test_srs_filter_pop_and_persistence(tmp_path):
+    ranks = {"apple": 1, "banana": 2, "carrot": 3}
+    filt = SRSFilter(ranks)
+
+    now = datetime.now()
+    # Make apple and banana overdue by different amounts
+    filt.schedulers["apple"].state.next_review = now - timedelta(days=2)
+    filt.schedulers["banana"].state.next_review = now - timedelta(days=1)
+    # Set intervals to avoid divide-by-zero when computing forgetting probability
+    filt.schedulers["apple"].state.interval = 1
+    filt.schedulers["banana"].state.interval = 1
+    filt.schedulers["carrot"].state.interval = 1
+    filt.schedulers["carrot"].state.next_review = now + timedelta(days=1)
+
+    assert filt.pop_next_due() == "apple"
+
+    # After reviewing apple it's no longer due; banana should be next
+    filt.review("apple", 5)
+    assert filt.pop_next_due() == "banana"
+
+    # Save and reload state; banana should remain next due
+    path = tmp_path / "state.json"
+    filt.save_state(path)
+    loaded = SRSFilter.load_state(path)
+    assert loaded.pop_next_due() == "banana"


### PR DESCRIPTION
## Summary
- add `SRSFilter` to manage spaced repetition state across many words
- support JSON persistence of review data
- provide priority-based retrieval using forgetting probability and goal frequency
- extend tests for filter persistence and review order

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e789b88ec832d9ea63f8c996e2e83