### PR TITLE
Add MCQ lesson generation with grammar tips

### DIFF
--- a/src/language_learning/__init__.py
+++ b/src/language_learning/__init__.py
@@ -2,12 +2,13 @@
 
 from .vocabulary import extract_vocabulary
 from .spaced_repetition import SpacedRepetitionScheduler
-from .ai_lessons import generate_lesson
+from .ai_lessons import generate_lesson, generate_mcq_lesson
 from .media_integration import suggest_media
 
 __all__ = [
     "extract_vocabulary",
     "SpacedRepetitionScheduler",
     "generate_lesson",
+    "generate_mcq_lesson",
     "suggest_media",
 ]

--- a/src/language_learning/ai_lessons.py
+++ b/src/language_learning/ai_lessons.py
@@ -1,4 +1,4 @@
-"""Stub for AI-driven lesson generation."""
+"""Minimal helpers for AI-driven lesson generation."""
 
 from typing import Dict, List, Optional
 
@@ -19,6 +19,60 @@ def generate_lesson(topic: str, vocabulary: Optional[List[str]] = None) -> Dict[
         "vocabulary": vocabulary or [],
         "exercise": f"Use {topic} in a sentence.",
     }
+    return lesson
+
+
+def _generate_distractors(word: str) -> List[str]:
+    """Return placeholder distractors for *word*.
+
+    The implementation is intentionally simple and deterministic.  A future
+    version of this project is expected to use an LLM to craft believable
+    distractors based on context.
+    """
+
+    return [f"{word}_{suffix}" for suffix in ("a", "b", "c")]
+
+
+def generate_mcq_lesson(
+    topic: str, new_words: List[str], review_words: List[str]
+) -> List[Dict[str, object]]:
+    """Return a sequence of MCQ prompts and grammar micro-lessons.
+
+    The resulting lesson alternates between multiple-choice questions for new
+    and review vocabulary and simple grammar tips.  Each word yields an MCQ
+    followed by a grammar hint.  ``new_words`` and ``review_words`` are
+    interleaved so that learners constantly revisit prior material while
+    encountering new vocabulary.
+    """
+
+    def mcq_entry(word: str) -> Dict[str, object]:
+        answer = f"meaning of {word}"
+        choices = [answer] + _generate_distractors(word)
+        return {
+            "type": "mcq",
+            "word": word,
+            "question": f"What is the meaning of '{word}'?",
+            "choices": choices,
+            "answer": answer,
+        }
+
+    def grammar_entry(word: str) -> Dict[str, str]:
+        return {
+            "type": "grammar_tip",
+            "tip": f"Remember the grammar rule associated with '{word}'.",
+        }
+
+    lesson: List[Dict[str, object]] = []
+    max_len = max(len(new_words), len(review_words))
+    for i in range(max_len):
+        if i < len(new_words):
+            word = new_words[i]
+            lesson.append(mcq_entry(word))
+            lesson.append(grammar_entry(word))
+        if i < len(review_words):
+            word = review_words[i]
+            lesson.append(mcq_entry(word))
+            lesson.append(grammar_entry(word))
     return lesson
 
 

--- a/tests/test_ai_lessons.py
+++ b/tests/test_ai_lessons.py
@@ -1,7 +1,25 @@
-from language_learning.ai_lessons import generate_lesson
+from language_learning.ai_lessons import generate_lesson, generate_mcq_lesson
 
 
 def test_generate_lesson():
     lesson = generate_lesson("food", ["apple"])
     assert lesson["topic"] == "food"
     assert "apple" in lesson["vocabulary"]
+
+
+def test_generate_mcq_lesson_interleaves_and_has_grammar():
+    lesson = generate_mcq_lesson(
+        "greetings",
+        new_words=["hola", "adios"],
+        review_words=["gracias", "por favor"],
+    )
+
+    types = [item["type"] for item in lesson]
+    for i in range(0, len(types), 2):
+        assert types[i] == "mcq"
+        assert types[i + 1] == "grammar_tip"
+
+    mcq_words = [item["word"] for item in lesson if item["type"] == "mcq"]
+    assert mcq_words == ["hola", "gracias", "adios", "por favor"]
+
+    assert any(item["type"] == "grammar_tip" for item in lesson)


### PR DESCRIPTION
## Summary
- implement `generate_mcq_lesson` to interleave new and review vocabulary with grammar tips
- provide placeholder distractor generation for MCQ options
- expose the new function at the package level and test its behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e7a445f94832d97b9cc9ec60adf90