### PR TITLE
Enhance media suggestions with L+1 filtering and interaction tracking

### DIFF
--- a/src/language_learning/__init__.py
+++ b/src/language_learning/__init__.py
@@ -3,7 +3,7 @@
 from .vocabulary import extract_vocabulary
 from .spaced_repetition import SpacedRepetitionScheduler
 from .ai_lessons import generate_lesson, generate_mcq_lesson
-from .media_integration import suggest_media
+from .media_integration import record_media_interaction, suggest_media
 
 __all__ = [
     "extract_vocabulary",
@@ -11,4 +11,5 @@ __all__ = [
     "generate_lesson",
     "generate_mcq_lesson",
     "suggest_media",
+    "record_media_interaction",
 ]

--- a/src/language_learning/media_integration.py
+++ b/src/language_learning/media_integration.py
@@ -1,18 +1,97 @@
-"""Basic media suggestion utilities."""
+"""Media suggestion and interaction tracking utilities."""
 
-from typing import Dict
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List, Tuple
 
 
-def suggest_media(word: str) -> Dict[str, str]:
-    """Return placeholder media links for *word*."""
-    base = "https://example.com/media"
-    return {
-        "audio": f"{base}/{word}.mp3",
-        "video": f"{base}/{word}.mp4",
-        "image": f"{base}/{word}.jpg",
-    }
+# ---------------------------------------------------------------------------
+# Example media catalogue used for tests and demonstrations.
+_BASE = "https://example.com/media"
+_MEDIA_LIBRARY: Dict[str, List[Dict[str, str]]] = {
+    # Each word has media items at various difficulty levels.  Only the
+    # L+1 level items should be returned by :func:`suggest_media`.
+    "word": [
+        {
+            "id": "word_lvl1",
+            "level": 1,
+            "audio": f"{_BASE}/word_level1.mp3",
+            "video": f"{_BASE}/word_level1.mp4",
+            "image": f"{_BASE}/word_level1.jpg",
+        },
+        {
+            "id": "word_lvl2",
+            "level": 2,
+            "audio": f"{_BASE}/word_level2.mp3",
+            "video": f"{_BASE}/word_level2.mp4",
+            "image": f"{_BASE}/word_level2.jpg",
+            "transcript": "Example transcript for level 2 media.",
+        },
+        {
+            "id": "word_lvl3",
+            "level": 3,
+            "audio": f"{_BASE}/word_level3.mp3",
+            "video": f"{_BASE}/word_level3.mp4",
+            "image": f"{_BASE}/word_level3.jpg",
+        },
+    ],
+    "another": [
+        {
+            "id": "another_lvl2",
+            "level": 2,
+            "audio": f"{_BASE}/another_level2.mp3",
+            "video": f"{_BASE}/another_level2.mp4",
+            "image": f"{_BASE}/another_level2.jpg",
+        }
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Interaction queue handling
+# ``interaction_queue`` maps user IDs to a list of ``(media_id, word)`` tuples.
+interaction_queue: Dict[str, List[Tuple[str, str]]] = defaultdict(list)
+
+
+def suggest_media(word: str, level: int) -> List[Dict[str, str]]:
+    """Return media entries for *word* at the learner's ``L+1`` difficulty.
+
+    Parameters
+    ----------
+    word:
+        Vocabulary item for which media is requested.
+    level:
+        Current learner difficulty level.  Only media at ``level + 1`` are
+        returned.
+
+    Returns
+    -------
+    List[Dict[str, str]]
+        Media items matching the requested word filtered to the ``L+1`` level.
+        Each item may contain an optional ``transcript`` key in addition to
+        the media URLs.
+    """
+
+    target = level + 1
+    return [
+        item for item in _MEDIA_LIBRARY.get(word, []) if item.get("level") == target
+    ]
+
+
+def record_media_interaction(user_id: str, media_id: str, word: str) -> None:
+    """Store that ``user_id`` interacted with ``word`` in ``media_id``.
+
+    The interactions are appended to :data:`interaction_queue` for later spaced
+    repetition review.
+    """
+
+    interaction_queue[user_id].append((media_id, word))
 
 
 if __name__ == "__main__":  # pragma: no cover - example usage
-    sample = suggest_media("language")
-    print(sample)
+    # Demonstrate media suggestion and interaction recording
+    items = suggest_media("word", 1)
+    for entry in items:
+        print(entry)
+    record_media_interaction("demo_user", items[0]["id"], "word")
+    print(dict(interaction_queue))

--- a/tests/test_media_integration.py
+++ b/tests/test_media_integration.py
@@ -1,8 +1,27 @@
-from language_learning.media_integration import suggest_media
+from language_learning.media_integration import (
+    suggest_media,
+    record_media_interaction,
+    interaction_queue,
+)
 
 
-def test_suggest_media():
-    media = suggest_media("word")
-    assert media["audio"].endswith("word.mp3")
-    assert media["video"].endswith("word.mp4")
-    assert media["image"].endswith("word.jpg")
+def test_suggest_media_lplus1_filtering():
+    results = suggest_media("word", 1)
+    assert len(results) == 1
+    item = results[0]
+    assert item["level"] == 2
+    # transcript is optional but present for the L+1 item in the catalogue
+    assert "transcript" in item
+
+
+def test_record_media_interaction_queueing():
+    interaction_queue.clear()
+    record_media_interaction("alice", "media1", "word")
+    record_media_interaction("alice", "media2", "another")
+    record_media_interaction("bob", "media3", "word")
+
+    assert interaction_queue["alice"] == [
+        ("media1", "word"),
+        ("media2", "another"),
+    ]
+    assert interaction_queue["bob"] == [("media3", "word")]

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -20,5 +20,5 @@ def test_package_exports(tmp_path):
     assert lesson["topic"] == "food"
     assert "apple" in lesson["vocabulary"]
 
-    media = suggest_media("word")
-    assert media["audio"].endswith("word.mp3")
+    media = suggest_media("word", 1)
+    assert media and media[0]["audio"].endswith("word_level2.mp3")


### PR DESCRIPTION
## Summary
- Extend media suggestion functionality to support level-aware L+1 filtering and optional transcripts.
- Track user media interactions in a per-user queue for spaced-repetition review and expose via package API.
- Update and expand tests to verify new media filtering and interaction queueing behavior.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e7b3adad4832db93c0f05eb7ce8c5