### PR TITLE
Add template-based AI blurb generator

### DIFF
--- a/src/language_learning/__init__.py
+++ b/src/language_learning/__init__.py
@@ -4,6 +4,7 @@ from .vocabulary import extract_vocabulary
 from .spaced_repetition import SpacedRepetitionScheduler
 from .ai_lessons import generate_lesson, generate_mcq_lesson
 from .media_integration import record_media_interaction, suggest_media
+from .ai_blurbs import generate_blurb
 
 __all__ = [
     "extract_vocabulary",
@@ -12,4 +13,5 @@ __all__ = [
     "generate_mcq_lesson",
     "suggest_media",
     "record_media_interaction",
+    "generate_blurb",
 ]

--- a/src/language_learning/ai_blurbs.py
+++ b/src/language_learning/ai_blurbs.py
@@ -1,0 +1,45 @@
+"""Generate short blurbs using restricted vocabulary.
+
+This module currently implements a deterministic, template-based approach for
+producing short text snippets that only use words from a provided whitelist.
+A private ``_generate_with_llm`` function serves as a placeholder for future
+large language model integration.
+"""
+
+from typing import Iterable, List
+
+
+def generate_blurb(
+    known_words: Iterable[str],
+    l_plus_one_words: Iterable[str],
+    length: int,
+) -> str:
+    """Return a short blurb using only whitelisted vocabulary.
+
+    Parameters
+    ----------
+    known_words:
+        Iterable of words already known by the learner.
+    l_plus_one_words:
+        Iterable of new words (``L+1`` vocabulary) to introduce.
+    length:
+        Desired length of the blurb measured in number of words.  If ``length``
+        is less than one, an empty string is returned.
+    """
+    allowed = list(dict.fromkeys(list(l_plus_one_words) + list(known_words)))
+    if length <= 0 or not allowed:
+        return ""
+
+    words: List[str] = []
+    idx = 0
+    while len(words) < length:
+        words.append(allowed[idx % len(allowed)])
+        idx += 1
+
+    return " ".join(words)
+
+
+def _generate_with_llm(*args, **kwargs) -> str:  # pragma: no cover - stub
+    """Placeholder for future LLM-based generation."""
+    raise NotImplementedError("LLM integration not yet implemented")
+

--- a/tests/test_ai_blurbs.py
+++ b/tests/test_ai_blurbs.py
@@ -1,0 +1,20 @@
+import pytest
+
+from language_learning.ai_blurbs import generate_blurb
+
+
+def test_generate_blurb_restricts_vocabulary():
+    known = ["chat", "chien"]
+    l_plus = ["cheval"]
+    blurb = generate_blurb(known, l_plus, length=5)
+    words = blurb.split()
+    allowed = set(known + l_plus)
+    assert all(word in allowed for word in words)
+
+
+def test_generate_blurb_length_control():
+    known = ["hola"]
+    l_plus = ["bonjour"]
+    length = 3
+    blurb = generate_blurb(known, l_plus, length)
+    assert len(blurb.split()) == length


### PR DESCRIPTION
## Summary
- add `ai_blurbs.generate_blurb` for whitelist-based blurb generation with future LLM hook
- expose blurb generator in package exports
- test vocabulary restriction and word count controls

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e7e8fea78832db09f7fab1d131b55