### PR TITLE
Add JSON storage and FastAPI endpoints with tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ nltk>=3.8
 spacy>=3.7
 requests>=2.31
 pytest>=7.4
+fastapi>=0.110

--- a/src/language_learning/api.py
+++ b/src/language_learning/api.py
@@ -1,0 +1,54 @@
+"""Minimal FastAPI service exposing core project functionality."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .ai_lessons import generate_lesson
+from .goals import GoalItem, GoalManager
+from .media_integration import suggest_media
+from .storage import JSONStorage
+
+
+class GoalIn(BaseModel):
+    word: str
+    weight: float = 1.0
+
+
+def create_app(storage: Optional[JSONStorage] = None) -> FastAPI:
+    """Application factory used by tests and external runners."""
+
+    store = storage or JSONStorage("data.json")
+    goal_manager = GoalManager()
+    for item in store.load_goals():
+        goal_manager.create_goal(item)
+
+    app = FastAPI()
+
+    @app.post("/goals")
+    def add_goal(goal: GoalIn):
+        item = GoalItem(goal.word, goal.weight)
+        goal_manager.create_goal(item)
+        store.save_goals(goal_manager.list_goals())
+        return {"goals": [asdict(g) for g in goal_manager.list_goals()]}
+
+    @app.get("/goals")
+    def list_goals():
+        return {"goals": [asdict(g) for g in goal_manager.list_goals()]}
+
+    @app.get("/lesson")
+    def lesson(topic: str):
+        return generate_lesson(topic)
+
+    @app.get("/media")
+    def media(word: str, level: int):
+        return suggest_media(word, level)
+
+    return app
+
+
+app = create_app()

--- a/src/language_learning/storage.py
+++ b/src/language_learning/storage.py
@@ -1,0 +1,67 @@
+"""Simple JSON-based persistence helpers.
+
+This module provides a tiny wrapper around JSON files for persisting
+user profiles, goal lists and spaced-repetition review state.  The class
+is intentionally lightweight; callers supply the file path and interact
+through dedicated ``save_*`` and ``load_*`` methods.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from typing import Any, Dict, List, Optional
+
+from .goals import GoalItem
+
+
+class JSONStorage:
+    """Persist user, goal and review information in a JSON file."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _read(self) -> Dict[str, Any]:
+        if not os.path.exists(self.path):
+            return {}
+        with open(self.path, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+    def _write(self, data: Dict[str, Any]) -> None:
+        with open(self.path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh)
+
+    # ------------------------------------------------------------------
+    # User persistence
+    def save_user(self, user: Dict[str, Any]) -> None:
+        data = self._read()
+        data["user"] = user
+        self._write(data)
+
+    def load_user(self) -> Optional[Dict[str, Any]]:
+        return self._read().get("user")
+
+    # ------------------------------------------------------------------
+    # Goal persistence
+    def save_goals(self, goals: List[GoalItem]) -> None:
+        data = self._read()
+        data["goals"] = [asdict(g) for g in goals]
+        self._write(data)
+
+    def load_goals(self) -> List[GoalItem]:
+        data = self._read()
+        return [GoalItem(**info) for info in data.get("goals", [])]
+
+    # ------------------------------------------------------------------
+    # Review state persistence
+    def save_review_state(self, state: Dict[str, Any]) -> None:
+        data = self._read()
+        data["review_state"] = state
+        self._write(data)
+
+    def load_review_state(self) -> Dict[str, Any]:
+        data = self._read()
+        return data.get("review_state", {})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,40 @@
+import json
+from fastapi.testclient import TestClient
+
+from language_learning.api import create_app
+from language_learning.storage import JSONStorage
+
+
+def _make_client(tmp_path):
+    storage = JSONStorage(tmp_path / "data.json")
+    app = create_app(storage)
+    return TestClient(app), storage
+
+
+def test_goal_setup_and_persistence(tmp_path):
+    client, storage = _make_client(tmp_path)
+
+    resp = client.post("/goals", json={"word": "hello"})
+    assert resp.status_code == 200
+    assert resp.json()["goals"][0]["word"] == "hello"
+
+    resp = client.get("/goals")
+    assert resp.status_code == 200
+    assert resp.json()["goals"] == [{"word": "hello", "weight": 1.0}]
+
+    with open(storage.path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert data["goals"][0]["word"] == "hello"
+
+
+def test_lesson_and_media_endpoints(tmp_path):
+    client, _ = _make_client(tmp_path)
+
+    resp = client.get("/lesson", params={"topic": "travel"})
+    assert resp.status_code == 200
+    assert resp.json()["topic"] == "travel"
+
+    resp = client.get("/media", params={"word": "word", "level": 1})
+    assert resp.status_code == 200
+    items = resp.json()
+    assert items and all(item["level"] == 2 for item in items)


### PR DESCRIPTION
## Summary
- implement JSON-based storage for users, goals, and review state
- expose FastAPI endpoints for goal management, lesson generation, and media suggestions
- add tests exercising new API endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e7ff79e98832d85e6146e144934ca