### PR TITLE
feat: scaffold TypeScript backend services

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+COPY package.json tsconfig.json ./
+RUN npm install
+
+COPY services ./services
+COPY shared ./shared
+COPY index.ts ./
+
+RUN npm run build
+
+CMD ["node", "dist/index.js"]

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,0 +1,29 @@
+import { createAuthService } from './services/auth';
+import { createGoalService } from './services/goal';
+import { createLessonService } from './services/lesson';
+import { createMediaService } from './services/media';
+import { createAnalyticsService } from './services/analytics';
+
+const ports = {
+  auth: Number(process.env.AUTH_PORT) || 3001,
+  goal: Number(process.env.GOAL_PORT) || 3002,
+  lesson: Number(process.env.LESSON_PORT) || 3003,
+  media: Number(process.env.MEDIA_PORT) || 3004,
+  analytics: Number(process.env.ANALYTICS_PORT) || 3005,
+};
+
+createAuthService().listen(ports.auth, () =>
+  console.log(`Auth service listening on port ${ports.auth}`)
+);
+createGoalService().listen(ports.goal, () =>
+  console.log(`Goal service listening on port ${ports.goal}`)
+);
+createLessonService().listen(ports.lesson, () =>
+  console.log(`Lesson service listening on port ${ports.lesson}`)
+);
+createMediaService().listen(ports.media, () =>
+  console.log(`Media service listening on port ${ports.media}`)
+);
+createAnalyticsService().listen(ports.analytics, () =>
+  console.log(`Analytics service listening on port ${ports.analytics}`)
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "language-learning-backend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "ts-node-dev --respawn --transpileOnly index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.12.0",
+    "express": "^4.18.2",
+    "redis": "^4.6.7",
+    "openai": "^4.0.0"
+  },
+  "devDependencies": {
+    "prisma": "^5.12.0",
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.2",
+    "ts-node-dev": "^2.0.0",
+    "@types/express": "^4.17.21"
+  }
+}

--- a/backend/services/analytics/index.ts
+++ b/backend/services/analytics/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+export function createAnalyticsService() {
+  const app = express();
+  app.use(express.json());
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return app;
+}

--- a/backend/services/auth/index.ts
+++ b/backend/services/auth/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+export function createAuthService() {
+  const app = express();
+  app.use(express.json());
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return app;
+}

--- a/backend/services/goal/index.ts
+++ b/backend/services/goal/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+export function createGoalService() {
+  const app = express();
+  app.use(express.json());
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return app;
+}

--- a/backend/services/lesson/index.ts
+++ b/backend/services/lesson/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+export function createLessonService() {
+  const app = express();
+  app.use(express.json());
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return app;
+}

--- a/backend/services/media/index.ts
+++ b/backend/services/media/index.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+
+export function createMediaService() {
+  const app = express();
+  app.use(express.json());
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return app;
+}

--- a/backend/shared/ai/index.ts
+++ b/backend/shared/ai/index.ts
@@ -1,0 +1,1 @@
+export * from './openai';

--- a/backend/shared/ai/openai.ts
+++ b/backend/shared/ai/openai.ts
@@ -1,0 +1,16 @@
+import OpenAI from 'openai';
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function createEmbedding(input: string, model = 'text-embedding-3-small') {
+  const res = await client.embeddings.create({ model, input });
+  return res.data[0].embedding;
+}
+
+export async function callChatCompletion(prompt: string, model = 'gpt-3.5-turbo') {
+  const res = await client.chat.completions.create({
+    model,
+    messages: [{ role: 'user', content: prompt }],
+  });
+  return res.choices[0].message?.content ?? '';
+}

--- a/backend/shared/database/index.ts
+++ b/backend/shared/database/index.ts
@@ -1,0 +1,1 @@
+export { default as prisma } from './prisma';

--- a/backend/shared/database/prisma.ts
+++ b/backend/shared/database/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient({
+  datasources: {
+    db: {
+      url: process.env.DATABASE_URL,
+    },
+  },
+});
+
+export default prisma;

--- a/backend/shared/models/index.ts
+++ b/backend/shared/models/index.ts
@@ -1,0 +1,4 @@
+export interface User {
+  id: string;
+  email: string;
+}

--- a/backend/shared/utils/index.ts
+++ b/backend/shared/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './redis';

--- a/backend/shared/utils/redis.ts
+++ b/backend/shared/utils/redis.ts
@@ -1,0 +1,8 @@
+import { createClient } from 'redis';
+
+export function createRedisClient(url = process.env.REDIS_URL || 'redis://localhost:6379') {
+  const client = createClient({ url });
+  client.on('error', (err) => console.error('Redis error', err));
+  client.connect().catch(console.error);
+  return client;
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["index.ts", "services/**/*.ts", "shared/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- scaffold backend with TypeScript microservices for auth, goal, lesson, media, analytics
- add shared Prisma, Redis, and OpenAI utilities
- configure package scripts, tsconfig, and Dockerfile

## Testing
- `pytest`
- `npm install --prefix backend --no-package-lock`
- `npm run --prefix backend build`


------
https://chatgpt.com/codex/tasks/task_e_688e8f9d8c7c832d8963477292f0d984