### PR TITLE
Add environment templates and docker compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 __pycache__/
 node_modules/
 dist/
+# Environment variables
+.env
+.env.*
+!**/.env.example

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/ll_db
+REDIS_URL=redis://localhost:6379
+OPENAI_API_KEY=your_openai_api_key
+AWS_ACCESS_KEY_ID=your_access_key
+AWS_SECRET_ACCESS_KEY=your_secret_key
+S3_BUCKET=your_bucket_name
+S3_REGION=us-east-1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ll_db
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - '6379:6379'
+volumes:
+  pgdata:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## Summary
- provide backend and frontend `.env.example` files
- ignore local `.env` files in git
- add `docker-compose.yml` for Postgres and Redis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e93d649d0832dbc64cd667008880b