### PR TITLE
docs: add development and infrastructure guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 LanguageLearning provides resources and example code for building tools that make learning new languages more engaging. The repository now includes modular components for vocabulary extraction, spaced-repetition scheduling, AI-driven lesson generation, and basic media integration.
 
+## Repository Structure
+
+- `backend/` – TypeScript Express API server
+- `frontend/` – React web client built with Vite
+- `infra/` – Terraform configuration for AWS deployment
+- `docs/` – Additional project documentation
+
 ## Setup Requirements
 
 To get started, you will need:
@@ -62,6 +69,10 @@ the entire test suite with:
 ```bash
 pytest
 ```
+
+## Development Guide
+
+Instructions for local development, Docker usage, CI/CD, and deployment are documented in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md).
 
 ## Contribution Guidelines
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,96 @@
+# Development Guide
+
+## Repository Structure
+- `backend/` – TypeScript Express API server
+- `frontend/` – React web client built with Vite
+- `infra/` – Terraform configuration for AWS deployment
+- `docs/` – Project documentation and developer guides
+
+## Local Development
+
+### 1. Clone the repository
+```bash
+git clone <repo-url>
+cd LanguageLearning
+```
+
+### 2. Install dependencies
+
+**Python modules**
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+**Backend**
+```bash
+cd backend
+npm install
+```
+
+**Frontend**
+```bash
+cd frontend
+npm install
+```
+
+### 3. Start Docker services
+```bash
+docker-compose up -d
+```
+
+### 4. Run development servers
+
+**Backend**
+```bash
+cd backend
+npm run dev
+```
+
+**Frontend**
+```bash
+cd frontend
+npm run dev
+```
+
+## Testing and Linting
+
+### Backend
+```bash
+npm test
+npm run lint
+```
+
+### Frontend
+```bash
+npm test
+npm run lint
+```
+
+### Python modules
+```bash
+pytest
+```
+
+## CI/CD Pipeline
+
+GitHub Actions (or a similar CI service) can be configured to:
+1. Install dependencies for each component.
+2. Run linting and tests for backend, frontend, and Python modules.
+3. Build and publish Docker images.
+4. Execute Terraform in the `infra/` directory to provision infrastructure.
+
+## Terraform Deployment
+```bash
+cd infra
+terraform init
+terraform plan
+terraform apply
+```
+
+## AWS Prerequisites
+- AWS account and IAM credentials with necessary permissions.
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured (`aws configure`).
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) installed locally.
+- Optional: S3 bucket and DynamoDB table for Terraform remote state locking.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,13 @@
+# Infrastructure
+
+Terraform configuration for deploying LanguageLearning services to AWS lives in this directory.
+
+## Usage
+```bash
+cd infra
+terraform init
+terraform plan
+terraform apply
+```
+
+Ensure AWS credentials are configured before running Terraform commands. See [../docs/DEVELOPMENT.md](../docs/DEVELOPMENT.md#aws-prerequisites) for required prerequisites.


### PR DESCRIPTION
## Summary
- document repository layout and link to developer guide
- add developer guide covering local setup, testing, CI/CD, and Terraform deployment
- scaffold infra directory with Terraform usage notes

## Testing
- `pytest`
- `cd backend && npm test` *(fails: Missing script "test")*
- `cd backend && npm run lint` *(fails: Missing script "lint")*
- `cd frontend && npm test` *(fails: Missing script "test")*
- `cd frontend && npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_688e95491794832db334e3c2433bfbff