### PR TITLE
Use Azure OpenAI client

### DIFF
--- a/backend/shared/ai/openai.ts
+++ b/backend/shared/ai/openai.ts
@@ -1,13 +1,20 @@
 import OpenAI from 'openai';
 
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = new OpenAI({
+  baseURL: `${process.env.AZURE_OPENAI_ENDPOINT}/openai/deployments/${process.env.AZURE_OPENAI_DEPLOYMENT}`,
+  defaultHeaders: { 'api-key': process.env.AZURE_OPENAI_API_KEY! },
+  defaultQuery: { 'api-version': '2025-01-01-preview' },
+});
 
 export async function createEmbedding(input: string, model = 'text-embedding-3-small') {
   const res = await client.embeddings.create({ model, input });
   return res.data[0].embedding;
 }
 
-export async function callChatCompletion(prompt: string, model = 'gpt-3.5-turbo') {
+export async function callChatCompletion(
+  prompt: string,
+  model = process.env.AZURE_OPENAI_DEPLOYMENT!,
+) {
   const res = await client.chat.completions.create({
     model,
     messages: [{ role: 'user', content: prompt }],


### PR DESCRIPTION
## Summary
- configure OpenAI client for Azure deployment with base URL, API key header, and API version query
- default chat completions to the Azure deployment while reusing the client for embeddings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e99162f50832d975847e3f4a9b9f6