### PR TITLE
Improve corpus file error handling

### DIFF
--- a/src/language_learning/vocabulary.py
+++ b/src/language_learning/vocabulary.py
@@ -7,6 +7,10 @@ from typing import List, Optional
 from .goals import GoalManager
 
 
+class CorpusReadError(Exception):
+    """Error raised when a corpus file cannot be read."""
+
+
 def extract_vocabulary(corpus_path: str, goals: Optional[GoalManager] = None) -> List[str]:
     """Extract words from a corpus ranked by goal-adjusted frequency.
 
@@ -23,9 +27,21 @@ def extract_vocabulary(corpus_path: str, goals: Optional[GoalManager] = None) ->
     List[str]
         Words sorted by adjusted frequency (descending) and
         alphabetically for ties.
+
+    Raises
+    ------
+    CorpusReadError
+        If ``corpus_path`` cannot be opened or decoded as UTF-8.
     """
-    with open(corpus_path, "r", encoding="utf-8") as f:
-        text = f.read().lower()
+    try:
+        with open(corpus_path, "r", encoding="utf-8") as f:
+            text = f.read().lower()
+    except FileNotFoundError as exc:
+        raise CorpusReadError(f"Corpus file not found: {corpus_path}") from exc
+    except UnicodeDecodeError as exc:
+        raise CorpusReadError(
+            f"Failed to decode corpus file as UTF-8: {corpus_path}"
+        ) from exc
     words = re.findall(r"\b\w+\b", text)
     counts = Counter(words)
     if goals:

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,4 +1,6 @@
-from language_learning.vocabulary import extract_vocabulary
+import pytest
+
+from language_learning.vocabulary import CorpusReadError, extract_vocabulary
 from language_learning.goals import GoalManager, GoalItem
 
 
@@ -15,3 +17,16 @@ def test_extract_vocabulary_with_goals(tmp_path):
     manager.create_goal(GoalItem(word="hello", weight=5))
     ranked = extract_vocabulary(str(corpus), manager)
     assert ranked[0] == "hello"
+
+
+def test_extract_vocabulary_missing_file(tmp_path):
+    missing = tmp_path / "missing.txt"
+    with pytest.raises(CorpusReadError):
+        extract_vocabulary(str(missing))
+
+
+def test_extract_vocabulary_bad_encoding(tmp_path):
+    bad = tmp_path / "bad.txt"
+    bad.write_bytes(b"\xff\xfe\xfd")
+    with pytest.raises(CorpusReadError):
+        extract_vocabulary(str(bad))


### PR DESCRIPTION
## Summary
- Add `CorpusReadError` and document its use in `extract_vocabulary`
- Wrap corpus file reads to raise informative errors on missing files or decode failures
- Test handling for missing corpus files and invalid encoding

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e9c2aa62c832d9d9a1e5e33d15285