### PR TITLE
Shuffle MCQ choices and track correct answer index

### DIFF
--- a/src/language_learning/ai_lessons.py
+++ b/src/language_learning/ai_lessons.py
@@ -1,6 +1,7 @@
 """Minimal helpers for AI-driven lesson generation."""
 
 from typing import Dict, List, Optional
+import random
 
 
 def generate_lesson(topic: str, vocabulary: Optional[List[str]] = None) -> Dict[str, object]:
@@ -48,12 +49,14 @@ def generate_mcq_lesson(
     def mcq_entry(word: str) -> Dict[str, object]:
         answer = f"meaning of {word}"
         choices = [answer] + _generate_distractors(word)
+        random.shuffle(choices)
         return {
             "type": "mcq",
             "word": word,
             "question": f"What is the meaning of '{word}'?",
             "choices": choices,
             "answer": answer,
+            "answer_index": choices.index(answer),
         }
 
     def grammar_entry(word: str) -> Dict[str, str]:

--- a/tests/test_ai_lessons.py
+++ b/tests/test_ai_lessons.py
@@ -23,3 +23,14 @@ def test_generate_mcq_lesson_interleaves_and_has_grammar():
     assert mcq_words == ["hola", "gracias", "adios", "por favor"]
 
     assert any(item["type"] == "grammar_tip" for item in lesson)
+
+
+def test_mcq_shuffles_and_tracks_answer():
+    import random
+
+    random.seed(0)
+    lesson = generate_mcq_lesson("greetings", new_words=["hola"], review_words=[])
+    mcq = lesson[0]
+    assert mcq["choices"][mcq["answer_index"]] == mcq["answer"]
+    assert set(mcq["choices"]) == {mcq["answer"], "hola_a", "hola_b", "hola_c"}
+    assert mcq["choices"] != [mcq["answer"], "hola_a", "hola_b", "hola_c"]


### PR DESCRIPTION
## Summary
- Randomize MCQ answer choices and store the index of the correct answer
- Add tests ensuring shuffled choices still reference the correct answer

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9d8d9f14832d86a2e43daecdd383