### PR TITLE
Expose backend service endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,30 @@
+# Backend Services
+
+Each service runs as an independent Express application. The default ports
+are configured in `index.ts` (3001–3005).
+
+## Auth Service
+- `GET /health` – service status
+- `POST /register` – create a user `{ username, password }`
+- `POST /login` – authenticate and receive a mock token
+- `GET /users` – list registered users
+- `DELETE /users/:id` – remove a user
+
+## Goal Service
+- `GET /health`
+- `GET /goals` – list goals via the Python goal manager
+- `POST /goals` – add a goal `{ word, weight }`
+- `PUT /goals/:word` – update an existing goal's weight
+- `DELETE /goals/:word` – remove a goal
+
+## Lesson Service
+- `GET /health`
+- `GET /lesson?topic=TOPIC` – generate a lesson using Python code
+
+## Media Service
+- `GET /health`
+- `GET /media?word=WORD&level=LEVEL` – suggest media for a word using Python
+
+## Analytics Service
+- `GET /health`
+- `GET /reports` – return mock analytics data

--- a/backend/services/analytics/index.ts
+++ b/backend/services/analytics/index.ts
@@ -4,5 +4,10 @@ export function createAnalyticsService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  app.get('/reports', (_req, res) => {
+    res.json({ activeUsers: 0, lessonsCompleted: 0 });
+  });
+
   return app;
 }

--- a/backend/services/auth/index.ts
+++ b/backend/services/auth/index.ts
@@ -4,5 +4,44 @@ export function createAuthService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  type User = { id: number; username: string; password: string };
+  const users: User[] = [];
+  let nextId = 1;
+
+  app.post('/register', (req, res) => {
+    const { username, password } = req.body;
+    if (!username || !password) {
+      return res.status(400).json({ error: 'username and password required' });
+    }
+    const user: User = { id: nextId++, username, password };
+    users.push(user);
+    res.status(201).json({ id: user.id, username: user.username });
+  });
+
+  app.post('/login', (req, res) => {
+    const { username, password } = req.body;
+    const user = users.find((u) => u.username === username && u.password === password);
+    if (!user) {
+      return res.status(401).json({ error: 'invalid credentials' });
+    }
+    // Return a mock token
+    res.json({ token: `mock-token-${user.id}` });
+  });
+
+  app.get('/users', (_req, res) => {
+    res.json({ users: users.map(({ password, ...rest }) => rest) });
+  });
+
+  app.delete('/users/:id', (req, res) => {
+    const id = Number(req.params.id);
+    const idx = users.findIndex((u) => u.id === id);
+    if (idx === -1) {
+      return res.status(404).json({ error: 'user not found' });
+    }
+    users.splice(idx, 1);
+    res.status(204).send();
+  });
+
   return app;
 }

--- a/backend/services/goal/index.ts
+++ b/backend/services/goal/index.ts
@@ -1,8 +1,106 @@
 import express from 'express';
+import path from 'path';
+import { runPython } from '../../shared/utils';
 
 export function createGoalService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  const dataPath = path.resolve(__dirname, '../../../data.json');
+
+  app.get('/goals', (_req, res) => {
+    const code = `
+import json, sys
+from language_learning.storage import JSONStorage
+from language_learning.goals import GoalManager
+from dataclasses import asdict
+store=JSONStorage(sys.argv[1])
+manager=GoalManager()
+for item in store.load_goals():
+    manager.create_goal(item)
+print(json.dumps({"goals": [asdict(g) for g in manager.list_goals()]}))
+`;
+    try {
+      const result = runPython(code, [dataPath]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.post('/goals', (req, res) => {
+    const { word, weight } = req.body;
+    if (!word) {
+      return res.status(400).json({ error: 'word required' });
+    }
+    const code = `
+import json, sys
+from language_learning.storage import JSONStorage
+from language_learning.goals import GoalManager, GoalItem
+from dataclasses import asdict
+store=JSONStorage(sys.argv[1])
+manager=GoalManager()
+for item in store.load_goals():
+    manager.create_goal(item)
+manager.create_goal(GoalItem(sys.argv[2], float(sys.argv[3])))
+store.save_goals(manager.list_goals())
+print(json.dumps({"goals": [asdict(g) for g in manager.list_goals()]}))
+`;
+    try {
+      const result = runPython(code, [dataPath, word, String(weight ?? 1)]);
+      res.status(201).json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.put('/goals/:word', (req, res) => {
+    const { word } = req.params;
+    const { weight } = req.body;
+    const code = `
+import json, sys
+from language_learning.storage import JSONStorage
+from language_learning.goals import GoalManager
+from dataclasses import asdict
+store=JSONStorage(sys.argv[1])
+manager=GoalManager()
+for item in store.load_goals():
+    manager.create_goal(item)
+manager.update_goal(sys.argv[2], float(sys.argv[3]))
+store.save_goals(manager.list_goals())
+print(json.dumps({"goals": [asdict(g) for g in manager.list_goals()]}))
+`;
+    try {
+      const result = runPython(code, [dataPath, word, String(weight ?? 1)]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.delete('/goals/:word', (req, res) => {
+    const { word } = req.params;
+    const code = `
+import json, sys
+from language_learning.storage import JSONStorage
+from language_learning.goals import GoalManager
+from dataclasses import asdict
+store=JSONStorage(sys.argv[1])
+manager=GoalManager()
+for item in store.load_goals():
+    manager.create_goal(item)
+manager.delete_goal(sys.argv[2])
+store.save_goals(manager.list_goals())
+print(json.dumps({"goals": [asdict(g) for g in manager.list_goals()]}))
+`;
+    try {
+      const result = runPython(code, [dataPath, word]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
   return app;
 }

--- a/backend/services/lesson/index.ts
+++ b/backend/services/lesson/index.ts
@@ -1,8 +1,26 @@
 import express from 'express';
+import { runPython } from '../../shared/utils';
 
 export function createLessonService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  app.get('/lesson', (req, res) => {
+    const topic = (req.query.topic as string) || '';
+    const code = `
+import json, sys
+from language_learning.ai_lessons import generate_lesson
+topic=sys.argv[1]
+print(json.dumps(generate_lesson(topic)))
+`;
+    try {
+      const lesson = runPython(code, [topic]);
+      res.json(lesson);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
   return app;
 }

--- a/backend/services/media/index.ts
+++ b/backend/services/media/index.ts
@@ -1,8 +1,28 @@
 import express from 'express';
+import { runPython } from '../../shared/utils';
 
 export function createMediaService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  app.get('/media', (req, res) => {
+    const word = (req.query.word as string) || '';
+    const level = Number(req.query.level || 1);
+    const code = `
+import json, sys
+from language_learning.media_integration import suggest_media
+word=sys.argv[1]
+level=int(sys.argv[2])
+print(json.dumps(suggest_media(word, level)))
+`;
+    try {
+      const media = runPython(code, [word, String(level)]);
+      res.json(media);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
   return app;
 }

--- a/backend/shared/utils/index.ts
+++ b/backend/shared/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './redis';
+export * from './python';

--- a/backend/shared/utils/python.ts
+++ b/backend/shared/utils/python.ts
@@ -1,0 +1,19 @@
+import { spawnSync } from 'child_process';
+
+export function runPython(code: string, args: string[] = []) {
+  const result = spawnSync('python', ['-c', code, ...args], {
+    encoding: 'utf-8',
+    env: { ...process.env, PYTHONPATH: 'src' },
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.stderr) {
+    const err = result.stderr.toString();
+    if (err.trim()) {
+      throw new Error(err);
+    }
+  }
+  const stdout = result.stdout.toString().trim();
+  return stdout ? JSON.parse(stdout) : null;
+}


### PR DESCRIPTION
## Summary
- add CRUD endpoints for auth and goals
- proxy lesson and media endpoints to Python modules
- document service routes in backend README

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e9ffe2c04832dbad1717f594c0ad3