### PR TITLE
Add analytics progress endpoints and UI

### DIFF
--- a/backend/services/analytics/index.ts
+++ b/backend/services/analytics/index.ts
@@ -1,10 +1,66 @@
 import express from 'express';
+import { runPython } from '../../shared/utils';
+import { DATA_PATH } from '../../shared/database';
 
 export function createAnalyticsService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
+  // Overall progress: number of learned words vs total goals
+  app.get('/progress', (_req, res) => {
+    const code = `
+import json, sys
+from language_learning.storage import JSONStorage
+store=JSONStorage(sys.argv[1])
+goals=store.load_goals()
+review=store.load_review_state()
+print(json.dumps({"learned": len(review), "total": len(goals)}))
+`;
+    try {
+      const result = runPython(code, [DATA_PATH]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // Next five review items based on spaced repetition state
+  app.get('/reviews/next', (_req, res) => {
+    const code = `
+import json, sys
+from datetime import datetime
+from language_learning.storage import JSONStorage
+from language_learning.spaced_repetition import SRSFilter, SpacedRepetitionScheduler
+store=JSONStorage(sys.argv[1])
+goals=store.load_goals()
+review=store.load_review_state()
+goal_ranks={g.word: i+1 for i,g in enumerate(goals)}
+filt=SRSFilter(goal_ranks)
+for word, info in review.items():
+    st=filt.schedulers.setdefault(word, SpacedRepetitionScheduler()).state
+    st.repetitions=int(info.get('repetitions',0))
+    st.interval=int(info.get('interval',0))
+    st.efactor=float(info.get('efactor',2.5))
+    st.next_review=datetime.fromisoformat(info['next_review'])
+next_words=[]
+for _ in range(5):
+    nxt=filt.pop_next_due()
+    if not nxt:
+        break
+    next_words.append(nxt)
+    del filt.schedulers[nxt]
+print(json.dumps({"next": next_words}))
+`;
+    try {
+      const result = runPython(code, [DATA_PATH]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // Legacy reports endpoint
   app.get('/reports', (_req, res) => {
     res.json({ activeUsers: 0, lessonsCompleted: 0 });
   });

--- a/backend/services/goal/index.ts
+++ b/backend/services/goal/index.ts
@@ -2,13 +2,14 @@ import express from 'express';
 import path from 'path';
 import fs from 'fs';
 import { runPython } from '../../shared/utils';
+import { DATA_PATH } from '../../shared/database';
 
 export function createGoalService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
-  const dataPath = path.resolve(__dirname, '../../../data.json');
+  const dataPath = DATA_PATH;
 
   app.get('/goals', (_req, res) => {
     const code = `

--- a/backend/shared/database/data.ts
+++ b/backend/shared/database/data.ts
@@ -1,0 +1,46 @@
+import fs from 'fs';
+import path from 'path';
+
+export const DATA_PATH = path.resolve(__dirname, '../../../data.json');
+
+interface DataFile {
+  goals: { word: string; weight?: number }[];
+  review_state: Record<string, any>;
+}
+
+function readFile(): DataFile {
+  try {
+    const raw = fs.readFileSync(DATA_PATH, 'utf-8');
+    const data = JSON.parse(raw);
+    return {
+      goals: Array.isArray(data.goals) ? data.goals : [],
+      review_state: data.review_state || {},
+    };
+  } catch {
+    return { goals: [], review_state: {} };
+  }
+}
+
+function writeFile(data: DataFile) {
+  fs.writeFileSync(DATA_PATH, JSON.stringify(data));
+}
+
+export function loadGoals() {
+  return readFile().goals;
+}
+
+export function saveGoals(goals: { word: string; weight?: number }[]) {
+  const data = readFile();
+  data.goals = goals;
+  writeFile(data);
+}
+
+export function loadReviewState() {
+  return readFile().review_state;
+}
+
+export function saveReviewState(state: Record<string, any>) {
+  const data = readFile();
+  data.review_state = state;
+  writeFile(data);
+}

--- a/backend/shared/database/index.ts
+++ b/backend/shared/database/index.ts
@@ -1,1 +1,2 @@
 export { default as prisma } from './prisma';
+export * from './data';

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -1,9 +1,51 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Dashboard() {
+  const [progress, setProgress] = useState({ learned: 0, total: 0 });
+  const [next, setNext] = useState([]);
+
+  useEffect(() => {
+    fetch('/analytics/progress')
+      .then((r) => r.json())
+      .then((data) => setProgress(data))
+      .catch(() => {});
+    fetch('/analytics/reviews/next')
+      .then((r) => r.json())
+      .then((data) => setNext(data.next || []))
+      .catch(() => {});
+  }, []);
+
+  const pct = progress.total ? Math.round((progress.learned / progress.total) * 100) : 0;
+
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Dashboard</h1>
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+
+      <div className="mb-6">
+        <div className="flex justify-between mb-1">
+          <span>Progress</span>
+          <span>
+            {progress.learned}/{progress.total}
+          </span>
+        </div>
+        <div className="w-full bg-gray-200 rounded">
+          <div
+            className="bg-blue-500 text-xs leading-none py-1 text-center text-white rounded"
+            style={{ width: `${pct}%` }}
+          >
+            {pct}%
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Next words to review</h2>
+        <ul className="list-disc pl-5">
+          {next.map((w) => (
+            <li key={w}>{w}</li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }

--- a/frontend/src/screens/GoalView.jsx
+++ b/frontend/src/screens/GoalView.jsx
@@ -1,9 +1,51 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function GoalView() {
+  const [progress, setProgress] = useState({ learned: 0, total: 0 });
+  const [next, setNext] = useState([]);
+
+  useEffect(() => {
+    fetch('/analytics/progress')
+      .then((r) => r.json())
+      .then((data) => setProgress(data))
+      .catch(() => {});
+    fetch('/analytics/reviews/next')
+      .then((r) => r.json())
+      .then((data) => setNext(data.next || []))
+      .catch(() => {});
+  }, []);
+
+  const pct = progress.total ? Math.round((progress.learned / progress.total) * 100) : 0;
+
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold">Goal View</h1>
+      <h1 className="text-2xl font-bold mb-4">Goal View</h1>
+
+      <div className="mb-6">
+        <div className="flex justify-between mb-1">
+          <span>Progress</span>
+          <span>
+            {progress.learned}/{progress.total}
+          </span>
+        </div>
+        <div className="w-full bg-gray-200 rounded">
+          <div
+            className="bg-green-500 text-xs leading-none py-1 text-center text-white rounded"
+            style={{ width: `${pct}%` }}
+          >
+            {pct}%
+          </div>
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-xl font-semibold mb-2">Next words to review</h2>
+        <ul className="list-disc pl-5">
+          {next.map((w) => (
+            <li key={w}>{w}</li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Display learned progress bars and next review words on Dashboard and GoalView screens
- Add analytics service endpoints for learner progress and upcoming reviews
- Introduce simple file-based data adapter for goal and review persistence

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea550c3c4832d8392f60641d9a522