### PR TITLE
feat: add lesson queue and review endpoints

### DIFF
--- a/backend/services/lesson/index.ts
+++ b/backend/services/lesson/index.ts
@@ -1,10 +1,82 @@
 import express from 'express';
+import path from 'path';
 import { runPython } from '../../shared/utils';
 
 export function createLessonService() {
   const app = express();
   app.use(express.json());
   app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+
+  const statePath = path.join(__dirname, 'srs_state.json');
+
+  app.get('/queue', (_req, res) => {
+    const code = `
+import json, sys
+from language_learning.spaced_repetition import SRSFilter
+from language_learning.ai_lessons import generate_mcq_lesson
+
+state_path = sys.argv[1]
+vocab = {"hola":1, "adios":2, "gracias":3, "por favor":4}
+filt = SRSFilter.load_state(state_path)
+if not filt.schedulers:
+    filt = SRSFilter(vocab)
+    filt.save_state(state_path)
+
+review_words = []
+while True:
+    nxt = filt.pop_next_due()
+    if not nxt:
+        break
+    review_words.append(nxt)
+
+new_words = [w for w in vocab if w not in filt.schedulers or filt.schedulers[w].state.repetitions == 0]
+new_words = [w for w in new_words if w not in review_words][:3]
+lesson = generate_mcq_lesson("practice", new_words, review_words)
+print(json.dumps({"lesson": lesson, "words": list(dict.fromkeys(new_words + review_words))}))
+`;
+    try {
+      const result = runPython(code, [statePath]) || { lesson: [], words: [] };
+      const queue = [...(result.lesson || [])];
+      const words: string[] = result.words || [];
+      words.forEach((word) => {
+        queue.push({
+          type: 'fill_blank',
+          word,
+          sentence: `Type the word '${word}'`,
+          answer: word,
+        });
+        queue.push({
+          type: 'matching',
+          word,
+          options: [word, `${word}_alt`],
+          answer: word,
+        });
+      });
+      res.json({ queue });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  app.post('/review', (req, res) => {
+    const { word, quality } = req.body as { word: string; quality: number };
+    const code = `
+import json, sys
+from language_learning.spaced_repetition import SRSFilter
+
+state_path, word, quality = sys.argv[1], sys.argv[2], int(sys.argv[3])
+filt = SRSFilter.load_state(state_path)
+filt.review(word, quality)
+filt.save_state(state_path)
+print(json.dumps({"next_review": filt.schedulers[word].state.next_review.isoformat()}))
+`;
+    try {
+      const result = runPython(code, [statePath, word, String(quality)]);
+      res.json(result);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message });
+    }
+  });
 
   app.get('/lesson', (req, res) => {
     const topic = (req.query.topic as string) || '';

--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -1,9 +1,160 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { apiClient } from '../services/api';
 
 export default function Learn() {
+  const [queue, setQueue] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [input, setInput] = useState('');
+  const [feedback, setFeedback] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const data = await apiClient('/lesson/queue');
+        setQueue(data.queue || []);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, []);
+
+  const current = queue[index];
+
+  const sendReview = async (word, quality) => {
+    try {
+      await apiClient('/lesson/review', {
+        method: 'POST',
+        body: { word, quality },
+      });
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const next = () => {
+    setInput('');
+    setIndex((i) => i + 1);
+  };
+
+  const handleMCQ = (choiceIdx) => {
+    const correct = choiceIdx === current.answer_index;
+    setFeedback(
+      correct
+        ? 'Correct!'
+        : `Incorrect. Answer: ${current.choices[current.answer_index]}`
+    );
+    sendReview(current.word, correct ? 5 : 2);
+    setTimeout(() => {
+      setFeedback('');
+      next();
+    }, 1000);
+  };
+
+  const handleFillBlank = () => {
+    const correct =
+      input.trim().toLowerCase() === current.answer.toLowerCase();
+    setFeedback(correct ? 'Correct!' : `Incorrect. Answer: ${current.answer}`);
+    sendReview(current.word, correct ? 5 : 2);
+    setTimeout(() => {
+      setFeedback('');
+      next();
+    }, 1000);
+  };
+
+  const handleMatchingDrop = (opt) => {
+    const correct = opt === current.answer;
+    setFeedback(correct ? 'Correct!' : `Incorrect. Answer: ${current.answer}`);
+    sendReview(current.word, correct ? 5 : 2);
+    setTimeout(() => {
+      setFeedback('');
+      next();
+    }, 1000);
+  };
+
+  if (!current) {
+    return (
+      <div className="p-4">
+        <h1 className="text-2xl font-bold">Learn</h1>
+        <p className="mt-4">No items due.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold">Learn</h1>
+
+      {current.type === 'mcq' && (
+        <div className="mt-4">
+          <p>{current.question}</p>
+          {current.choices.map((c, idx) => (
+            <button
+              key={idx}
+              onClick={() => handleMCQ(idx)}
+              className="block mt-2 p-2 border rounded"
+            >
+              {c}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {current.type === 'fill_blank' && (
+        <div className="mt-4">
+          <p>{current.sentence}</p>
+          <input
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            className="border p-1 mt-2"
+          />
+          <button
+            onClick={handleFillBlank}
+            className="ml-2 p-1 border rounded"
+          >
+            Submit
+          </button>
+        </div>
+      )}
+
+      {current.type === 'matching' && (
+        <div className="mt-4">
+          <p>Drag the word to its match:</p>
+          <div className="flex space-x-4 mt-2">
+            <div
+              draggable
+              onDragStart={(e) =>
+                e.dataTransfer.setData('text/plain', current.word)
+              }
+              className="p-2 border rounded"
+            >
+              {current.word}
+            </div>
+            {current.options.map((opt) => (
+              <div
+                key={opt}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={() => handleMatchingDrop(opt)}
+                className="p-2 border rounded"
+              >
+                {opt}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {current.type === 'grammar_tip' && (
+        <div className="mt-4">
+          <p className="italic">{current.tip}</p>
+          <button onClick={next} className="mt-2 p-1 border rounded">
+            Next
+          </button>
+        </div>
+      )}
+
+      {feedback && <p className="mt-4">{feedback}</p>}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add spaced-repetition queue and review endpoints
- expand Learn screen with MCQs, fill-in, matching, and grammar tips

## Testing
- `npm test --prefix frontend` (fails: Missing script: "test")
- `npm test --prefix backend` (fails: Missing script: "test")
- `npm run build --prefix backend`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ea78bca3c832d9fedaafe1bc76026