### PR TITLE
feat: expand microservice endpoints

### DIFF
--- a/backend/services/auth/index.ts
+++ b/backend/services/auth/index.ts
@@ -33,6 +33,21 @@ export function createAuthService() {
     res.json({ users: users.map(({ password, ...rest }) => rest) });
   });
 
+  app.put('/users/:id', (req, res) => {
+    const id = Number(req.params.id);
+    const { username, password } = req.body as {
+      username?: string;
+      password?: string;
+    };
+    const user = users.find((u) => u.id === id);
+    if (!user) {
+      return res.status(404).json({ error: 'user not found' });
+    }
+    if (username) user.username = username;
+    if (password) user.password = password;
+    res.json({ id: user.id, username: user.username });
+  });
+
   app.delete('/users/:id', (req, res) => {
     const id = Number(req.params.id);
     const idx = users.findIndex((u) => u.id === id);


### PR DESCRIPTION
## Summary
- add update route for auth users
- implement goal CRUD endpoints and vocabulary extraction via shared utilities
- deliver lesson queues and review updates using SRS state
- expose progress metrics and review queue for analytics

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eab0d0c64832d9c0d8245fc960576