### PR TITLE
feat: add python service bridge

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -94,3 +94,18 @@ terraform apply
 - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) configured (`aws configure`).
 - [Terraform](https://developer.hashicorp.com/terraform/downloads) installed locally.
 - Optional: S3 bucket and DynamoDB table for Terraform remote state locking.
+
+## Python service integration
+
+Some learning features are implemented in Python and exposed through a
+FastAPI microservice located in `src/language_learning/api.py`. Start the
+service locally with:
+
+```bash
+uvicorn language_learning.api:app --reload --port 8000
+```
+
+Node-based services communicate with this process via HTTP (configure the
+`PY_SERVICE_URL` environment variable if the service is not on
+`http://localhost:8000`). The lesson service then exposes endpoints under
+`/lesson` such as `/vocabulary`, `/prompts`, and `/blurb` for the front-end.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -17,3 +17,29 @@ export async function apiClient(endpoint, { method = 'GET', body, headers } = {}
   }
   return response.json();
 }
+
+export const fetchVocabulary = (corpus) =>
+  apiClient('/lesson/vocabulary', {
+    method: 'POST',
+    body: { corpus },
+  });
+
+export const fetchLessonPrompts = (topic, newWords = [], reviewWords = []) =>
+  apiClient('/lesson/prompts', {
+    method: 'POST',
+    body: { topic, new_words: newWords, review_words: reviewWords },
+  });
+
+export const generateBlurb = (
+  knownWords = [],
+  lPlusOneWords = [],
+  length = 0,
+) =>
+  apiClient('/lesson/blurb', {
+    method: 'POST',
+    body: {
+      known_words: knownWords,
+      l_plus_one_words: lPlusOneWords,
+      length,
+    },
+  });


### PR DESCRIPTION
## Summary
- expose vocabulary extraction, lesson prompts, and blurb generation via FastAPI
- bridge lesson service to call the Python microservice and proxy new endpoints
- add front-end helpers and docs for Python service integration

## Testing
- `pytest`
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd backend && npm run lint` *(fails: Missing script: "lint")*
- `cd frontend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_688eaefaa764832dbb37f9bd33717aba