### PR TITLE
docs: clarify AWS deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ simpler managed services depending on your needs.
    - An AWS account with credentials configured in your environment
      (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`).
 
-2. **Build and tag Docker images**
+2. **Build and push Docker images**
    ```bash
    docker build -t language-learning-backend ./backend
    docker build -t language-learning-frontend ./frontend
    ```
-   Push the images to a registry such as Amazon ECR or Docker Hub. Update image
-   tags in `infra/terraform.tfvars` if necessary.
+   Push the images to a registry such as Amazon ECR or Docker Hub. For ECR, log
+   in with `aws ecr get-login-password | docker login` and push the tagged
+   images. Update image tags in `infra/terraform.tfvars` if necessary.
 
 3. **Provision infrastructure**
    ```bash
@@ -103,9 +104,10 @@ simpler managed services depending on your needs.
    terraform plan       # review changes
    terraform apply      # create or update AWS resources
    ```
-   The Terraform code sets up an ECS Fargate cluster for containers, an RDS
-   PostgreSQL instance, networking components, and an S3/CloudFront distribution
-   for the front end.
+   Adjust values in `infra/terraform.tfvars` (region, domain, scaling options)
+   to match your environment. The Terraform code sets up an ECS Fargate cluster
+   for containers, an RDS PostgreSQL instance, networking components, and an
+   S3/CloudFront distribution for the front end.
 
 4. **Configure application**
    - Store sensitive values (API keys, database URLs, etc.) in AWS Secrets
@@ -123,22 +125,11 @@ simpler managed services depending on your needs.
    - Store AWS credentials and registry logins as encrypted secrets in the
      repository settings.
 
-### Alternative managed services
-
-If maintaining AWS infrastructure is more than you need, you can deploy smaller
-pieces to managed platforms that rebuild on each GitHub push:
-
-- **Frontend**: Connect `frontend/` to Vercel or Netlify for automatic builds and
-  CDN hosting.
-- **Backend and services**: Use Render, Railway, Fly.io, or Heroku. These
-  platforms can build from the `backend/` Dockerfile and provide managed
-  PostgreSQL/Redis add-ons.
-- **Database and cache**: Managed offerings such as Supabase or Neon (Postgres)
-  and Upstash (Redis) work well with the services above.
-
-Regardless of platform, define secrets in the hosting provider's dashboard and
-expose them to the application through environment variables so deployments
-remain reproducible and secure.
+6. **Set up DNS and SSL**
+   - Use Route 53 to manage your domain and create an alias record to the
+     CloudFront distribution or load balancer.
+   - Provision certificates with AWS Certificate Manager and reference them in
+     Terraform for HTTPS support.
 
 ## Contribution Guidelines
 


### PR DESCRIPTION
## Summary
- expand AWS instructions: push Docker images to ECR and customize Terraform variables
- guide on configuring DNS and SSL with Route 53 and ACM
- remove section on alternative managed services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eb4e88de8832db92bc5cca3b94022