### PR TITLE
Add starter Terraform scaffolding

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,98 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  backend "s3" {
+    bucket         = var.backend_state_bucket
+    key            = "terraform.tfstate"
+    region         = var.region
+    dynamodb_table = var.lock_table
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "network" {
+  source = "./modules/network"
+
+  vpc_cidr = var.vpc_cidr
+}
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  backend_image  = var.backend_image
+  frontend_image = var.frontend_image
+}
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  cluster_name    = "language-learning-cluster"
+  backend_image   = var.backend_image
+  frontend_image  = var.frontend_image
+  desired_count   = 2
+  vpc_id          = module.network.vpc_id
+  private_subnets = module.network.private_subnets
+}
+
+module "rds" {
+  source = "./modules/rds"
+
+  db_name     = var.db_name
+  username    = var.db_username
+  password    = var.db_password
+  subnet_ids  = module.network.private_subnets
+  vpc_id      = module.network.vpc_id
+}
+
+module "s3" {
+  source = "./modules/s3"
+
+  bucket_name = var.asset_bucket
+}
+
+module "cloudfront" {
+  source = "./modules/cloudfront"
+
+  origin_bucket = module.s3.bucket_id
+  domain_name   = var.domain_name
+  acm_cert_arn  = var.acm_certificate_arn
+}
+
+module "route53" {
+  source = "./modules/route53"
+
+  zone_id        = var.hosted_zone_id
+  domain_name    = var.domain_name
+  cloudfront_dns = module.cloudfront.domain_name
+}
+
+module "acm" {
+  source = "./modules/acm"
+
+  domain_name = var.domain_name
+}
+
+module "secrets_manager" {
+  source = "./modules/secrets"
+
+  db_password = var.db_password
+}
+
+module "ssm_parameters" {
+  source = "./modules/ssm"
+
+  parameters = {
+    DB_USERNAME = var.db_username
+    DB_PASSWORD = var.db_password
+  }
+}
+
+module "dynamodb" {
+  source = "./modules/dynamodb"
+
+  table_name = var.lock_table
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "cloudfront_domain" {
+  description = "CloudFront distribution domain name."
+  value       = module.cloudfront.domain_name
+}
+
+output "backend_service_url" {
+  description = "URL for the backend ECS service (if exposed)."
+  value       = module.ecs.backend_url
+}

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,17 @@
+region               = "us-east-1"
+backend_state_bucket = "ll-terraform-state"
+lock_table           = "ll-terraform-locks"
+
+backend_image  = "123456789012.dkr.ecr.us-east-1.amazonaws.com/ll-backend:latest"
+frontend_image = "123456789012.dkr.ecr.us-east-1.amazonaws.com/ll-frontend:latest"
+
+domain_name         = "example.com"
+hosted_zone_id      = "Z1234567890"
+acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abc-123"
+
+db_name      = "languagedb"
+db_username  = "admin"
+db_password  = "CHANGE_ME"
+
+vpc_cidr     = "10.0.0.0/16"
+asset_bucket = "ll-assets"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,65 @@
+variable "region" {
+  description = "AWS region to deploy resources in."
+  type        = string
+}
+
+variable "backend_state_bucket" {
+  description = "S3 bucket used for Terraform remote state."
+  type        = string
+}
+
+variable "lock_table" {
+  description = "DynamoDB table for Terraform state locking."
+  type        = string
+}
+
+variable "backend_image" {
+  description = "ECR image URI for the backend."
+  type        = string
+}
+
+variable "frontend_image" {
+  description = "ECR image URI for the frontend."
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Root domain for the application."
+  type        = string
+}
+
+variable "hosted_zone_id" {
+  description = "Route 53 hosted zone ID."
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for CloudFront."
+  type        = string
+}
+
+variable "db_name" {
+  description = "Name of the RDS database."
+  type        = string
+}
+
+variable "db_username" {
+  description = "Username for the RDS database."
+  type        = string
+}
+
+variable "db_password" {
+  description = "Password for the RDS database."
+  type        = string
+  sensitive   = true
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC."
+  type        = string
+}
+
+variable "asset_bucket" {
+  description = "S3 bucket name for static assets."
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add main Terraform configuration with AWS provider, remote state backend, and module stubs
- declare infrastructure variables and sample tfvars values
- expose sample outputs for CloudFront and ECS

## Testing
- `pytest`
- `terraform fmt` *(fails: command not found)*
- `apt-get install -y terraform` *(fails: Unable to locate package terraform)*

------
https://chatgpt.com/codex/tasks/task_e_688ec26337d4832d91e3401b4d4b7120