### PR TITLE
Use variables for Terraform backend and provider

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -2,16 +2,16 @@ terraform {
   required_version = ">= 1.5.0"
 
   backend "s3" {
-    bucket         = "langlearn-terraform-state"
+    bucket         = var.backend_state_bucket
     key            = "terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "langlearn-terraform-lock"
+    region         = var.region
+    dynamodb_table = var.lock_table
     encrypt        = true
   }
 }
 
 provider "aws" {
-  region = "us-west-2"
+  region = var.region
 }
 
 

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -9,9 +9,9 @@ domain_name         = "example.com"
 hosted_zone_id      = "Z1234567890"
 acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/abc-123"
 
-db_name      = "languagedb"
-db_username  = "admin"
-db_password  = "CHANGE_ME"
+db_name     = "languagedb"
+db_username = "admin"
+db_password = "CHANGE_ME"
 
 vpc_cidr     = "10.0.0.0/16"
 asset_bucket = "ll-assets"


### PR DESCRIPTION
## Summary
- reference backend state bucket, region, and lock table variables in Terraform backend and provider configuration
- ensure terraform.tfvars defines region and state bucket settings with consistent formatting

## Testing
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate` *(fails: Reference to undeclared module)*

------
https://chatgpt.com/codex/tasks/task_e_688ecad67fac832db957af3131e5b7dc