### PR TITLE
Refactor CloudFront setup and add assets bucket

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -14,88 +14,16 @@ provider "aws" {
   region = var.region
 }
 
+resource "aws_s3_bucket" "assets" {
+  bucket = var.asset_bucket
+}
+
 module "cloudfront" {
   source       = "./modules/cloudfront"
-  asset_bucket = var.asset_bucket
+  asset_bucket = aws_s3_bucket.assets.bucket
 }
 
 module "ecs" {
   source        = "./modules/ecs"
   backend_image = var.backend_image
-}
-
-
-resource "aws_cloudfront_distribution" "cdn" {
-  origin {
-    domain_name = aws_s3_bucket.assets.website_endpoint
-    origin_id   = "S3-assets"
-  }
-  enabled             = true
-  default_root_object = "index.html"
-  default_cache_behavior {
-    allowed_methods        = ["GET","HEAD"]
-    cached_methods         = ["GET","HEAD"]
-    target_origin_id       = "S3-assets"
-    viewer_protocol_policy = "redirect-to-https"
-    forwarded_values {
-      query_string = false
-      cookies { forward = "none" }
-    }
-  }
-  viewer_certificate {
-    cloudfront_default_certificate = true
-  }
-  restrictions {
-    geo_restriction { restriction_type = "none" }
-  }
-}
-
-resource "aws_cloudfront_distribution" "cdn" {
-  origin {
-    domain_name = aws_s3_bucket.assets.website_endpoint
-    origin_id   = "S3-assets"
-  }
-  enabled             = true
-  default_root_object = "index.html"
-  default_cache_behavior {
-    allowed_methods        = ["GET","HEAD"]
-    cached_methods         = ["GET","HEAD"]
-    target_origin_id       = "S3-assets"
-    viewer_protocol_policy = "redirect-to-https"
-    forwarded_values {
-      query_string = false
-      cookies { forward = "none" }
-    }
-  }
-  viewer_certificate {
-    cloudfront_default_certificate = true
-  }
-  restrictions {
-    geo_restriction { restriction_type = "none" }
-  }
-}
-
-resource "aws_cloudfront_distribution" "cdn" {
-  origin {
-    domain_name = aws_s3_bucket.assets.website_endpoint
-    origin_id   = "S3-assets"
-  }
-  enabled             = true
-  default_root_object = "index.html"
-  default_cache_behavior {
-    allowed_methods        = ["GET","HEAD"]
-    cached_methods         = ["GET","HEAD"]
-    target_origin_id       = "S3-assets"
-    viewer_protocol_policy = "redirect-to-https"
-    forwarded_values {
-      query_string = false
-      cookies { forward = "none" }
-    }
-  }
-  viewer_certificate {
-    cloudfront_default_certificate = true
-  }
-  restrictions {
-    geo_restriction { restriction_type = "none" }
-  }
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -23,14 +23,17 @@ variable "frontend_image" {
   type        = string
 }
 
+variable "root_domain" {
   description = "Root domain for the application."
   type        = string
 }
 
+variable "hosted_zone_id" {
   description = "Route 53 hosted zone ID."
   type        = string
 }
 
+variable "certificate_arn" {
   description = "ARN of the ACM certificate for CloudFront."
   type        = string
 }


### PR DESCRIPTION
## Summary
- provision S3 bucket for static assets and use it in CloudFront module
- remove duplicate CloudFront distribution resources
- add missing variable declarations for root domain, hosted zone ID and certificate ARN

## Testing
- `terraform fmt variables.tf main.tf`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_688eeee4c1cc832d99926ee8e96887f0