### PR TITLE
feat: add ECS service module

### DIFF
--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -1,1 +1,130 @@
-# ECS module placeholder
+resource "aws_ecs_cluster" "this" {
+  name = "backend-cluster"
+}
+
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "backend-task-exec"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "backend" {
+  family                   = "backend"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "backend"
+      image     = var.backend_image
+      essential = true
+      portMappings = [
+        {
+          containerPort = 8000
+          hostPort      = 8000
+          protocol      = "tcp"
+        }
+      ]
+    }
+  ])
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "this" {
+  count      = 2
+  vpc_id     = aws_vpc.this.id
+  cidr_block = cidrsubnet(aws_vpc.this.cidr_block, 8, count.index)
+}
+
+resource "aws_security_group" "service" {
+  name        = "backend-sg"
+  description = "Allow inbound HTTP to backend service"
+  vpc_id      = aws_vpc.this.id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 8000
+    to_port     = 8000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "this" {
+  name               = "backend-lb"
+  load_balancer_type = "application"
+  subnets            = aws_subnet.this[*].id
+  security_groups    = [aws_security_group.service.id]
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "backend-tg"
+  port        = 8000
+  protocol    = "HTTP"
+  target_type = "ip"
+  vpc_id      = aws_vpc.this.id
+
+  health_check {
+    path = "/"
+  }
+}
+
+resource "aws_lb_listener" "this" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+resource "aws_ecs_service" "this" {
+  name            = "backend-service"
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.backend.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = aws_subnet.this[*].id
+    security_groups  = [aws_security_group.service.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = "backend"
+    container_port   = 8000
+  }
+
+  depends_on = [aws_lb_listener.this]
+}

--- a/infra/modules/ecs/outputs.tf
+++ b/infra/modules/ecs/outputs.tf
@@ -1,4 +1,4 @@
 output "backend_url" {
   description = "URL for the backend ECS service."
-  value       = ""
+  value       = aws_lb.this.dns_name
 }


### PR DESCRIPTION
## Summary
- define ECS cluster, task definition, service, load balancer, and IAM roles
- output backend service DNS

## Testing
- `terraform init -no-color`
- `terraform plan -var backend_image=example/backend:latest -no-color`

------
https://chatgpt.com/codex/tasks/task_e_688ef023ee00832dbfd7ff7467f28a4c