### PR TITLE
feat(frontend): make API base URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ simpler managed services depending on your needs.
 2. **Build and push Docker images**
    ```bash
    docker build -t language-learning-backend ./backend
-   docker build -t language-learning-frontend ./frontend
+   docker build -t language-learning-frontend --build-arg VITE_API_URL="https://backend.example.com" ./frontend
    ```
+   Replace `https://backend.example.com` with your backend's public endpoint.
    Push the images to a registry such as Amazon ECR or Docker Hub. For ECR, log
    in with `aws ecr get-login-password | docker login` and push the tagged
    images. Update image tags in `infra/terraform.tfvars` (copy from the example file) if necessary.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
-VITE_API_BASE_URL=http://localhost:3000
+# Base URL for backend API
+VITE_API_URL=/api

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install
 COPY . .
+ARG VITE_API_URL
+ENV VITE_API_URL=${VITE_API_URL}
 RUN npm run build
 
 # Production stage

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,44 @@
+# Frontend
+
+React web client built with Vite.
+
+## Environment Variables
+
+- `VITE_API_URL` – Base URL for the backend API. Defaults to `/api`.
+  Set this to the backend's public endpoint when building for production.
+  The value is read at build time and can be provided via a `.env` file or
+  environment variables.
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+Optionally create a `.env` file to override the default API URL:
+
+```bash
+VITE_API_URL=http://localhost:8000
+```
+
+## Building
+
+Build the production bundle, providing `VITE_API_URL` if the backend is not
+served from the same origin:
+
+```bash
+VITE_API_URL=https://backend.example.com npm run build
+```
+
+Alternatively, define `VITE_API_URL` in a `.env.production` file.
+
+## Deployment
+
+When creating the Docker image, pass the backend endpoint as a build argument:
+
+```bash
+docker build --build-arg VITE_API_URL=https://backend.example.com -t language-learning-frontend .
+```
+
+This embeds the correct API URL into the built assets.

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = '/api';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api';
 
 export async function apiClient(endpoint, { method = 'GET', body, headers } = {}) {
   const config = {


### PR DESCRIPTION
## Summary
- allow configuring API URL via `VITE_API_URL`
- document `VITE_API_URL` and deployment instructions
- ensure Docker build passes through `VITE_API_URL`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688eff46b1b4832d90c010098c33faf6