### PR TITLE
Add ACM certificate ARN to Terraform vars

### DIFF
--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,0 +1,2 @@
+acm_certificate_arn = "arn:aws:acm:us-west-2:202533523636:certificate/5826402f-4318-4114-b563-dbeca18728e9"
+


### PR DESCRIPTION
## Summary
- include issued ACM certificate ARN in Terraform variable file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f770e0f14832d8eca328b38d7df00