### PR TITLE
Propagate VPC and domain variables to ECS module

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -35,9 +35,11 @@ module "cloudfront" {
 }
 
 module "ecs" {
-  source        = "./modules/ecs"
+  source          = "./modules/ecs"
   backend_image   = var.backend_image
   region          = var.region
   data_table_name = aws_dynamodb_table.data.name
   data_table_arn  = aws_dynamodb_table.data.arn
+  vpc_cidr        = var.vpc_cidr
+  root_domain     = var.root_domain
 }

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_task_definition" "backend" {
 }
 
 resource "aws_vpc" "this" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = var.vpc_cidr
 }
 
 resource "aws_subnet" "this" {
@@ -101,7 +101,7 @@ resource "aws_security_group" "service" {
 }
 
 resource "aws_lb" "this" {
-  name               = "backend-lb"
+  name               = "${var.root_domain}-lb"
   load_balancer_type = "application"
   subnets            = aws_subnet.this[*].id
   security_groups    = [aws_security_group.service.id]

--- a/infra/modules/ecs/variables.tf
+++ b/infra/modules/ecs/variables.tf
@@ -17,3 +17,13 @@ variable "data_table_arn" {
   description = "ARN of the DynamoDB table for application data."
   type        = string
 }
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC (passed from root)."
+  type        = string
+}
+
+variable "root_domain" {
+  description = "Apex domain (passed from root) for naming and tags."
+  type        = string
+}


### PR DESCRIPTION
## Summary
- pass VPC CIDR and root domain into ECS module
- use variables for VPC and load balancer configuration

## Testing
- `terraform -chdir=infra init -backend=false`
- `terraform -chdir=infra validate`


------
https://chatgpt.com/codex/tasks/task_e_688f829c8afc832da63b8eae11079007