### PR TITLE
Sanitize load balancer name

### DIFF
--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -114,7 +114,7 @@ resource "aws_subnet" "this" {
 }
 
 resource "aws_lb" "this" {
-  name               = "${var.root_domain}-lb"
+  name               = "${replace(var.root_domain, ".", "-")}-lb"
   load_balancer_type = "application"
   subnets            = aws_subnet.this[*].id
   security_groups    = [aws_security_group.service.id]


### PR DESCRIPTION
## Summary
- replace dots with hyphens in ECS load balancer name to satisfy AWS requirements

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f91b6831c832da510f56fef6052fb