### PR TITLE
feat: configure CloudFront with custom domain

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -30,8 +30,10 @@ resource "aws_dynamodb_table" "data" {
 }
 
 module "cloudfront" {
-  source       = "./modules/cloudfront"
-  asset_bucket = aws_s3_bucket.assets.bucket
+  source              = "./modules/cloudfront"
+  asset_bucket        = aws_s3_bucket.assets.bucket
+  root_domain         = var.root_domain
+  acm_certificate_arn = var.acm_certificate_arn
 }
 
 module "ecs" {

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -1,6 +1,7 @@
 resource "aws_cloudfront_distribution" "this" {
   enabled             = true
   default_root_object = "index.html"
+  aliases             = ["www.${var.root_domain}"]
 
   origin {
     domain_name = "${var.asset_bucket}.s3.amazonaws.com"
@@ -34,6 +35,8 @@ resource "aws_cloudfront_distribution" "this" {
   }
 
   viewer_certificate {
-    cloudfront_default_certificate = true
+    acm_certificate_arn      = var.acm_certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2018"
   }
 }

--- a/infra/modules/cloudfront/variables.tf
+++ b/infra/modules/cloudfront/variables.tf
@@ -2,3 +2,13 @@ variable "asset_bucket" {
   description = "S3 bucket containing static assets."
   type        = string
 }
+
+variable "root_domain" {
+  description = "Root domain for the CloudFront distribution."
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ARN of the ACM certificate for the distribution."
+  type        = string
+}


### PR DESCRIPTION
## Summary
- serve CloudFront distribution under custom domain and ACM certificate
- expose module variables for root domain and certificate and wire them through root module

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_688fa60b3220832da9f6c7848b67fa74