### PR TITLE
Replace dots in load balancer name with hyphens

### DIFF
--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -135,7 +135,8 @@ resource "aws_route_table_association" "public" {
 }
 
 resource "aws_lb" "this" {
-  name               = "${var.root_domain}-lb"
+  # replace dots with hyphens so the LB name is valid
+  name               = "${replace(var.root_domain, ".", "-")}-lb"
   load_balancer_type = "application"
   subnets            = aws_subnet.this[*].id
   security_groups    = [aws_security_group.service.id]


### PR DESCRIPTION
## Summary
- sanitize ECS load balancer name by replacing dots with hyphens

## Testing
- `terraform init -backend=false`
- `terraform validate`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688fa97e78e0832d9b45f93e15b8099a