### PR TITLE
feat: add theme toggle and semantic classes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,9 +17,10 @@
     prefersDark.addEventListener('change', (e) => {
       root.dataset.theme = e.matches ? 'dark' : 'light';
     });
-    document.getElementById('theme-toggle').addEventListener('click', () => {
+    window.toggleTheme = () => {
       root.dataset.theme = root.dataset.theme === 'dark' ? 'light' : 'dark';
-    });
+    };
+    document.getElementById('theme-toggle').addEventListener('click', window.toggleTheme);
   </script>
   <script type="module" src="/src/main.jsx"></script>
 </body>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -11,14 +11,34 @@ const navItems = [
 ];
 
 export default function Layout({ children }) {
+  const handleToggle = () => {
+    if (window.toggleTheme) {
+      window.toggleTheme();
+    }
+  };
+
   return (
     <div className="min-h-screen flex flex-col">
-      <nav className="bg-blue-600 text-white p-4 flex space-x-4">
-        {navItems.map((item) => (
-          <Link key={item.path} to={item.path} className="hover:underline">
-            {item.label}
-          </Link>
-        ))}
+      <nav className="bg-secondary text-primary p-4 flex justify-between items-center">
+        <div className="flex space-x-4">
+          {navItems.map((item) => (
+            <Link
+              key={item.path}
+              to={item.path}
+              className="px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+            >
+              {item.label}
+            </Link>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-label="Toggle theme"
+          className="p-2 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+        >
+          Toggle Theme
+        </button>
       </nav>
       <main className="flex-1 p-4">{children}</main>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,9 +5,11 @@
 :root[data-theme="light"] {
   --bg-primary: #ffffff;
   --text-primary: #1a202c;
+  --bg-secondary: #e2e8f0;
 }
 
 :root[data-theme="dark"] {
   --bg-primary: #1a202c;
   --text-primary: #edf2f7;
+  --bg-secondary: #2d3748;
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -9,6 +9,8 @@ module.exports = {
       colors: {
         bg: "var(--bg-primary)",
         text: "var(--text-primary)",
+        primary: "var(--text-primary)",
+        secondary: "var(--bg-secondary)",
       },
     },
   },


### PR DESCRIPTION
## Summary
- replace hard-coded nav colors with semantic Tailwind utilities
- expose global theme toggle and add accessible toggle button to layout
- add secondary color tokens for light/dark modes

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900b5238c8832d92aa793276148f25