### PR TITLE
feat: add sidebar layout

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Sidebar from './Sidebar.jsx';
 
 const navItems = [
   { path: '/', label: 'Onboarding' },
@@ -18,9 +19,9 @@ export default function Layout({ children }) {
   };
 
   return (
-    <div className="min-h-screen flex flex-col">
-      <nav className="bg-secondary text-primary p-4 flex justify-between items-center">
-        <div className="flex space-x-4">
+    <div className="min-h-screen grid grid-rows-[auto,1fr] grid-cols-[16rem,1fr]">
+      <header className="bg-secondary text-primary p-4 flex justify-between items-center col-span-2">
+        <nav className="flex space-x-4">
           {navItems.map((item) => (
             <Link
               key={item.path}
@@ -30,7 +31,7 @@ export default function Layout({ children }) {
               {item.label}
             </Link>
           ))}
-        </div>
+        </nav>
         <button
           type="button"
           onClick={handleToggle}
@@ -39,8 +40,13 @@ export default function Layout({ children }) {
         >
           Toggle Theme
         </button>
-      </nav>
-      <main className="flex-1 p-4">{children}</main>
+      </header>
+      <aside className="border-r border-white/10 p-4">
+        <Sidebar />
+      </aside>
+      <main className="p-4 overflow-y-auto">
+        <section className="skill-path">{children}</section>
+      </main>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export default function Sidebar() {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-bold">Stats</h2>
+        <p>Streak: 0</p>
+        <p>Lingots: 0</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor layout to semantic grid with header, sidebar, and main content
- add sidebar component for basic stats display

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68901923b018832dacb7f902b32d97c0