### PR TITLE
Use NavLink for active navigation highlighting

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import Sidebar from './Sidebar.jsx';
 
 const navItems = [
@@ -23,13 +23,17 @@ export default function Layout({ children }) {
       <header className="bg-secondary text-primary p-4 flex justify-between items-center col-span-2">
         <nav className="flex space-x-4">
           {navItems.map((item) => (
-            <Link
+            <NavLink
               key={item.path}
               to={item.path}
-              className="px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+              className={({ isActive }) =>
+                `px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  isActive ? 'active' : ''
+                }`
+              }
             >
               {item.label}
-            </Link>
+            </NavLink>
           ))}
         </nav>
         <button

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,3 +21,9 @@
   --accent-secondary: #c53030;
   --text-inverse: #ffffff;
 }
+
+@layer components {
+  .active {
+    @apply bg-white/10 text-inverse;
+  }
+}


### PR DESCRIPTION
## Summary
- highlight active navigation item using NavLink
- add Tailwind `active` class for better visual feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901cd9ead0832d966552b1d4cf0130