### PR TITLE
Add responsive layout with collapsible sidebar

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import Sidebar from './Sidebar.jsx';
 
@@ -12,30 +12,46 @@ const navItems = [
 ];
 
 export default function Layout({ children }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   const handleToggle = () => {
     if (window.toggleTheme) {
       window.toggleTheme();
     }
   };
 
+  const toggleSidebar = () => setSidebarOpen((open) => !open);
+
   return (
-    <div className="min-h-screen grid grid-rows-[auto,1fr] grid-cols-[16rem,1fr]">
-      <header className="bg-secondary text-primary p-4 flex justify-between items-center col-span-2">
-        <nav className="flex space-x-4">
-          {navItems.map((item) => (
-            <NavLink
-              key={item.path}
-              to={item.path}
-              className={({ isActive }) =>
-                `px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
-                  isActive ? 'active' : ''
-                }`
-              }
-            >
-              {item.label}
-            </NavLink>
-          ))}
-        </nav>
+    <div className="min-h-screen grid grid-rows-[auto,1fr] md:grid-cols-[16rem,1fr] grid-cols-1">
+      <header className="bg-secondary text-primary p-4 flex justify-between items-center md:col-span-2">
+        <div className="flex items-center space-x-4">
+          <button
+            type="button"
+            onClick={toggleSidebar}
+            aria-label="Toggle navigation"
+            className="p-2 rounded md:hidden hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+          >
+            <span className="block w-6 h-0.5 bg-current" />
+            <span className="block w-6 h-0.5 bg-current my-1" />
+            <span className="block w-6 h-0.5 bg-current" />
+          </button>
+          <nav className="flex space-x-4">
+            {navItems.map((item) => (
+              <NavLink
+                key={item.path}
+                to={item.path}
+                className={({ isActive }) =>
+                  `px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                    isActive ? 'active' : ''
+                  }`
+                }
+              >
+                {item.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
         <button
           type="button"
           onClick={handleToggle}
@@ -45,7 +61,11 @@ export default function Layout({ children }) {
           Toggle Theme
         </button>
       </header>
-      <aside className="border-r border-white/10 p-4">
+      <aside
+        className={`border-r border-white/10 p-4 ${
+          sidebarOpen ? 'block' : 'hidden'
+        } md:block`}
+      >
         <Sidebar />
       </aside>
       <main className="p-4 overflow-y-auto">


### PR DESCRIPTION
## Summary
- make layout grid responsive and add sidebar state
- add hamburger toggle to show/hide sidebar on mobile

## Testing
- `cd frontend && npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68901f21237c832dbe347773dd0ff152