### PR TITLE
Add loading and error states to key screens

### DIFF
--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -4,17 +4,40 @@ import ProgressOverview from '../components/ProgressOverview.jsx';
 export default function Dashboard() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
   const [next, setNext] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    fetch('/analytics/progress')
-      .then((r) => r.json())
-      .then((data) => setProgress(data))
-      .catch(() => {});
-    fetch('/analytics/reviews/next')
-      .then((r) => r.json())
-      .then((data) => setNext(data.next || []))
-      .catch(() => {});
+    async function load() {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const [progressRes, nextRes] = await Promise.all([
+          fetch('/analytics/progress'),
+          fetch('/analytics/reviews/next'),
+        ]);
+        const progressData = await progressRes.json();
+        const nextData = await nextRes.json();
+        setProgress(progressData);
+        setNext(nextData.next || []);
+      } catch (err) {
+        setError('Unable to load dashboard data.');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    load();
   }, []);
 
-  return <ProgressOverview heading="Dashboard" progress={progress} next={next} />;
+  return (
+    <div aria-live="polite">
+      {isLoading ? (
+        <p>Loading...</p>
+      ) : error ? (
+        <p>{error}</p>
+      ) : (
+        <ProgressOverview heading="Dashboard" progress={progress} next={next} />
+      )}
+    </div>
+  );
 }

--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -6,14 +6,20 @@ export default function Learn() {
   const [index, setIndex] = useState(0);
   const [input, setInput] = useState('');
   const [feedback, setFeedback] = useState({ message: '', isCorrect: null });
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     async function load() {
       try {
+        setIsLoading(true);
+        setError(null);
         const data = await apiClient('/lesson/queue');
         setQueue(data.queue || []);
       } catch (err) {
-        console.error(err);
+        setError('Unable to load lesson.');
+      } finally {
+        setIsLoading(false);
       }
     }
     load();
@@ -23,12 +29,13 @@ export default function Learn() {
 
   const sendReview = async (word, quality) => {
     try {
+      setError(null);
       await apiClient('/lesson/review', {
         method: 'POST',
         body: { word, quality },
       });
     } catch (err) {
-      console.error(err);
+      setError('Failed to submit review.');
     }
   };
 
@@ -79,9 +86,25 @@ export default function Learn() {
     }, 1000);
   };
 
+  if (isLoading) {
+    return (
+      <div className="p-4" aria-live="polite">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4" aria-live="polite">
+        <p>{error}</p>
+      </div>
+    );
+  }
+
   if (!current) {
     return (
-      <div className="p-4">
+      <div className="p-4" aria-live="polite">
         <h1 className="text-2xl font-bold">Learn</h1>
         <p className="mt-4">No items due.</p>
       </div>
@@ -89,7 +112,7 @@ export default function Learn() {
   }
 
   return (
-    <div className="p-4">
+    <div className="p-4" aria-live="polite">
       <h1 className="text-2xl font-bold">Learn</h1>
 
       {current.type === 'mcq' && (


### PR DESCRIPTION
## Summary
- provide loading and error feedback in Dashboard, Onboarding, and Learn screens
- announce status changes with `aria-live="polite"`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890228dbd90832d84026ebbcd998d2b