### PR TITLE
feat: improve accessibility for learning flows

### DIFF
--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -117,30 +117,46 @@ export default function Learn() {
 
       {current.type === 'mcq' && (
         <div className="mt-4">
-          <p>{current.question}</p>
-          {current.choices.map((c, idx) => (
-            <button
-              key={idx}
-              onClick={() => handleMCQ(idx)}
-              className="block mt-2 p-2 border rounded"
-            >
-              {c}
-            </button>
-          ))}
+          <p id="mcq-question">{current.question}</p>
+          <div
+            role="radiogroup"
+            aria-labelledby="mcq-question"
+            aria-describedby="mcq-instructions"
+          >
+            {current.choices.map((c, idx) => (
+              <button
+                key={idx}
+                role="radio"
+                aria-checked="false"
+                onClick={() => handleMCQ(idx)}
+                className="block mt-2 p-2 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
+              >
+                {c}
+              </button>
+            ))}
+          </div>
+          <p id="mcq-instructions" className="text-sm text-gray-600">
+            Use Tab to focus an answer and Enter to select.
+          </p>
         </div>
       )}
 
       {current.type === 'fill_blank' && (
         <div className="mt-4">
-          <p>{current.sentence}</p>
+          <p id="fill-sentence">{current.sentence}</p>
+          <label htmlFor="fill-input" className="block mt-2">
+            Your answer
+          </label>
           <input
+            id="fill-input"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            className="border p-1 mt-2"
+            className="border p-1 focus:outline focus:outline-2 focus:outline-offset-2"
+            aria-labelledby="fill-sentence"
           />
           <button
             onClick={handleFillBlank}
-            className="ml-2 p-1 border rounded"
+            className="ml-2 p-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
           >
             Submit
           </button>
@@ -177,7 +193,10 @@ export default function Learn() {
       {current.type === 'grammar_tip' && (
         <div className="mt-4">
           <p className="italic">{current.tip}</p>
-          <button onClick={next} className="mt-2 p-1 border rounded">
+          <button
+            onClick={next}
+            className="mt-2 p-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
+          >
             Next
           </button>
         </div>

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -80,31 +80,53 @@ export default function Onboarding() {
       {step === 1 && (
         <div>
           <h1 className="text-2xl font-bold mb-4">Choose your first goal</h1>
-          <div className="space-x-2 mb-4">
+          <div
+            className="space-x-2 mb-2"
+            role="group"
+            aria-label="Goal templates"
+            aria-describedby="template-instructions"
+          >
             {Object.keys(TEMPLATE_TEXT).map((name) => (
               <button
                 key={name}
                 onClick={() => handleTemplate(name)}
-                className={`px-3 py-1 border rounded ${
+                className={`px-3 py-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2 ${
                   template === name ? 'bg-accent-primary text-inverse' : ''
                 }`}
+                aria-label={`Use ${name} template`}
               >
                 {name}
               </button>
             ))}
           </div>
+          <p id="template-instructions" className="text-sm text-gray-600 mb-4">
+            Use Tab to focus template buttons and Enter to select.
+          </p>
+          <label htmlFor="goal-text" className="block mb-1">
+            Enter or paste your own text
+          </label>
           <textarea
+            id="goal-text"
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder="Or enter your own text"
-            className="w-full border p-2 mb-2 h-40"
+            className="w-full border p-2 mb-2 h-40 focus:outline focus:outline-2 focus:outline-offset-2"
           />
-          <input type="file" accept=".txt" onChange={handleFile} className="mb-4" />
+          <label htmlFor="goal-file" className="block mb-1">
+            Upload a text file
+          </label>
+          <input
+            id="goal-file"
+            type="file"
+            accept=".txt"
+            onChange={handleFile}
+            className="mb-4 focus:outline focus:outline-2 focus:outline-offset-2"
+          />
           <div>
             <button
               onClick={startExtraction}
               disabled={isLoading}
-              className="bg-accent-primary text-inverse px-4 py-2 rounded"
+              className="bg-accent-primary text-inverse px-4 py-2 rounded focus:outline focus:outline-2 focus:outline-offset-2"
             >
               Next
             </button>
@@ -130,7 +152,7 @@ export default function Onboarding() {
           <button
             onClick={saveGoals}
             disabled={isLoading}
-            className="bg-accent-primary text-inverse px-4 py-2 rounded"
+            className="bg-accent-primary text-inverse px-4 py-2 rounded focus:outline focus:outline-2 focus:outline-offset-2"
           >
             Save Goals
           </button>


### PR DESCRIPTION
## Summary
- add aria roles and labels on onboarding inputs and template buttons
- label fill-in-the-blank inputs and mark MCQ options as radio buttons
- show visible focus outlines and keyboard navigation cues

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689023d79868832da48eb8bbd3ce9b64