### PR TITLE
feat: add user stats to sidebar

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -26,6 +26,7 @@ export default function Layout({ children }) {
             type="button"
             onClick={toggleSidebar}
             aria-label="Toggle navigation"
+            aria-expanded={sidebarOpen}
             className="p-2 rounded md:hidden hover:bg-white/5 focus:bg-white/5 focus:outline-none"
           >
             <span className="block w-6 h-0.5 bg-current" />
@@ -58,9 +59,9 @@ export default function Layout({ children }) {
         </button>
       </header>
       <aside
-        className={`border-r border-white/10 p-4 ${
-          sidebarOpen ? 'block' : 'hidden'
-        } md:block`}
+        className={`border-r border-white/10 p-4 bg-secondary fixed inset-y-0 left-0 w-64 transform transition-transform duration-300 ease-in-out ${
+          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
+        } md:static md:translate-x-0 md:w-auto md:block`}
       >
         <Sidebar />
       </aside>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,12 +1,53 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 export default function Sidebar() {
+  const [stats, setStats] = useState({ streak: 0, lingots: 0 });
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let ignore = false;
+    async function loadStats() {
+      try {
+        const res = await fetch('/api/user/stats');
+        if (!res.ok) throw new Error('Failed to load');
+        const data = await res.json();
+        if (!ignore) {
+          setStats({
+            streak: data.streak ?? 0,
+            lingots: data.lingots ?? 0,
+          });
+        }
+      } catch (err) {
+        if (!ignore) {
+          setError('Unable to load stats');
+        }
+      }
+    }
+    loadStats();
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
   return (
     <div className="space-y-4">
       <div>
         <h2 className="font-bold">Stats</h2>
-        <p>Streak: 0</p>
-        <p>Lingots: 0</p>
+        {error && (
+          <p role="alert" className="text-red-500">
+            {error}
+          </p>
+        )}
+        <dl className="space-y-1" aria-live="polite">
+          <div className="flex justify-between">
+            <dt>Streak</dt>
+            <dd>{stats.streak}</dd>
+          </div>
+          <div className="flex justify-between">
+            <dt>Lingots</dt>
+            <dd>{stats.lingots}</dd>
+          </div>
+        </dl>
       </div>
     </div>
   );

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import Sidebar from './Sidebar.jsx';
+
+expect.extend(matchers);
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ streak: 3, lingots: 7 }),
+      })
+    ));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('fetches and displays user stats', async () => {
+    const { container } = render(<Sidebar />);
+    expect(fetch).toHaveBeenCalledWith('/api/user/stats');
+    await waitFor(() => {
+      expect(screen.getByText('Streak')).toBeInTheDocument();
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText('Lingots')).toBeInTheDocument();
+      expect(screen.getByText('7')).toBeInTheDocument();
+    });
+    const dl = container.querySelector('dl');
+    expect(dl).toHaveAttribute('aria-live', 'polite');
+  });
+});


### PR DESCRIPTION
## Summary
- fetch user stats from API and show in sidebar
- slide-in sidebar on small screens for better mobile usability
- add tests for sidebar stats display

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890273ac130832d813e4c526ac96dcf