### PR TITLE
feat(ui): add shared components and theme tokens

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import Sidebar from './Sidebar.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
+import Button from './ui/Button';
 
 const navItems = [
   { path: '/', label: 'Onboarding' },
@@ -20,26 +21,27 @@ export default function Layout({ children }) {
 
   return (
     <div className="min-h-screen grid grid-rows-[auto,1fr] md:grid-cols-[16rem,1fr] grid-cols-1">
-      <header className="bg-secondary text-primary p-4 flex justify-between items-center md:col-span-2">
-        <div className="flex items-center space-x-4">
-          <button
+      <header className="bg-secondary text-primary p-md flex justify-between items-center md:col-span-2">
+        <div className="flex items-center space-x-lg">
+          <Button
             type="button"
             onClick={toggleSidebar}
             aria-label="Toggle navigation"
             aria-expanded={sidebarOpen}
-            className="p-2 rounded md:hidden hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+            variant="secondary"
+            className="md:hidden"
           >
             <span className="block w-6 h-0.5 bg-current" />
             <span className="block w-6 h-0.5 bg-current my-1" />
             <span className="block w-6 h-0.5 bg-current" />
-          </button>
-          <nav className="flex space-x-4">
+          </Button>
+          <nav className="flex space-x-lg">
             {navItems.map((item) => (
               <NavLink
                 key={item.path}
                 to={item.path}
                 className={({ isActive }) =>
-                  `px-2 py-1 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  `px-sm py-xs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
                     isActive ? 'active' : ''
                   }`
                 }
@@ -49,23 +51,23 @@ export default function Layout({ children }) {
             ))}
           </nav>
         </div>
-        <button
+        <Button
           type="button"
           onClick={toggleTheme}
           aria-label="Toggle theme"
-          className="p-2 rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none"
+          variant="secondary"
         >
           Toggle Theme
-        </button>
+        </Button>
       </header>
       <aside
-        className={`border-r border-white/10 p-4 bg-secondary fixed inset-y-0 left-0 w-64 transform transition-transform duration-300 ease-in-out ${
+        className={`border-r border-white/10 p-md bg-secondary fixed inset-y-0 left-0 w-64 transform transition-transform duration-300 ease-in-out ${
           sidebarOpen ? 'translate-x-0' : '-translate-x-full'
         } md:static md:translate-x-0 md:w-auto md:block`}
       >
         <Sidebar />
       </aside>
-      <main className="p-4 overflow-y-auto">
+      <main className="p-md overflow-y-auto">
         <section className="skill-path">{children}</section>
       </main>
     </div>

--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+const base = 'px-md py-sm rounded focus:outline focus:outline-2 focus:outline-offset-2';
+const variants = {
+  primary: 'bg-accent-primary text-inverse',
+  secondary: 'bg-secondary text-text',
+  outline: 'border',
+};
+
+export default function Button({ variant = 'primary', className = '', ...props }) {
+  const styles = `${base} ${variants[variant] || ''} ${className}`;
+  return <button className={styles} {...props} />;
+}

--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+
+export default function Card({ className = '', ...props }) {
+  const base = 'bg-secondary text-text rounded shadow p-md';
+  return <div className={`${base} ${className}`} {...props} />;
+}

--- a/frontend/src/components/ui/Input.jsx
+++ b/frontend/src/components/ui/Input.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function Input({ as = 'input', className = '', ...props }) {
+  const Component = as;
+  const base = 'border rounded p-sm focus:outline focus:outline-2 focus:outline-offset-2';
+  return <Component className={`${base} ${className}`} {...props} />;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,18 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --font-sans: 'Inter', sans-serif;
+  --font-heading: 'Poppins', sans-serif;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+}
+
 :root[data-theme="light"] {
   --bg-primary: #ffffff;
   --text-primary: #1a202c;

--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { apiClient } from '../services/api';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import Card from '../components/ui/Card';
 
 export default function Learn() {
   const [queue, setQueue] = useState([]);
@@ -98,7 +101,7 @@ export default function Learn() {
 
   if (isLoading) {
     return (
-      <div className="p-4" aria-live="polite">
+      <div className="p-md" aria-live="polite">
         <p>Loading...</p>
       </div>
     );
@@ -106,7 +109,7 @@ export default function Learn() {
 
   if (error) {
     return (
-      <div className="p-4" aria-live="polite">
+      <div className="p-md" aria-live="polite">
         <p>{error}</p>
       </div>
     );
@@ -114,19 +117,19 @@ export default function Learn() {
 
   if (!current) {
     return (
-      <div className="p-4" aria-live="polite">
+      <div className="p-md" aria-live="polite">
         <h1 className="text-2xl font-bold">Learn</h1>
-        <p className="mt-4">No items due.</p>
+        <p className="mt-md">No items due.</p>
       </div>
     );
   }
 
   return (
-    <div className="p-4" aria-live="polite">
+    <div className="p-md" aria-live="polite">
       <h1 className="text-2xl font-bold">Learn</h1>
 
       {current.type === 'mcq' && (
-        <div className="mt-4">
+        <Card className="mt-md">
           <p id="mcq-question">{current.question}</p>
           <div
             role="radiogroup"
@@ -134,47 +137,44 @@ export default function Learn() {
             aria-describedby="mcq-instructions"
           >
             {current.choices.map((c, idx) => (
-              <button
+              <Button
                 key={idx}
                 role="radio"
                 aria-checked="false"
                 onClick={() => handleMCQ(idx)}
-                className="block mt-2 p-2 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
+                variant="outline"
+                className="block mt-sm w-full text-left"
               >
                 {c}
-              </button>
+              </Button>
             ))}
           </div>
           <p id="mcq-instructions" className="text-sm text-gray-600">
             Use Tab to focus an answer and Enter to select.
           </p>
-        </div>
+        </Card>
       )}
 
       {current.type === 'fill_blank' && (
-        <div className="mt-4">
+        <Card className="mt-md">
           <p id="fill-sentence">{current.sentence}</p>
           <label htmlFor="fill-input" className="block mt-2">
             Your answer
           </label>
-          <input
+          <Input
             id="fill-input"
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            className="border p-1 focus:outline focus:outline-2 focus:outline-offset-2"
             aria-labelledby="fill-sentence"
           />
-          <button
-            onClick={handleFillBlank}
-            className="ml-2 p-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
-          >
+          <Button onClick={handleFillBlank} className="ml-sm mt-sm" variant="outline">
             Submit
-          </button>
-        </div>
+          </Button>
+        </Card>
       )}
 
       {current.type === 'matching' && (
-        <div className="mt-4">
+        <Card className="mt-md">
           <p>Drag the word to its match:</p>
           <div className="flex space-x-4 mt-2">
             <div
@@ -197,25 +197,22 @@ export default function Learn() {
               </div>
             ))}
           </div>
-        </div>
+        </Card>
       )}
 
       {current.type === 'grammar_tip' && (
-        <div className="mt-4">
+        <Card className="mt-md">
           <p className="italic">{current.tip}</p>
-          <button
-            onClick={next}
-            className="mt-2 p-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2"
-          >
+          <Button onClick={next} className="mt-sm" variant="outline">
             Next
-          </button>
-        </div>
+          </Button>
+        </Card>
       )}
 
       {feedback.message && (
         <div
           key={index}
-          className={`mt-4 flex items-center p-2 rounded transition-all duration-300 transform ${
+          className={`mt-md flex items-center p-sm rounded transition-all duration-300 transform ${
             animateFeedback
               ? 'opacity-100 translate-y-0'
               : 'opacity-0 -translate-y-2'

--- a/frontend/src/screens/MediaExplorer.jsx
+++ b/frontend/src/screens/MediaExplorer.jsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useState } from 'react';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import Card from '../components/ui/Card';
 
 // Simple media explorer showing suggested media items and an AI blurb generator.
 export default function MediaExplorer() {
@@ -80,54 +83,42 @@ export default function MediaExplorer() {
   }
 
   return (
-    <div className="p-4 space-y-6">
+    <div className="p-md space-y-lg">
       <h1 className="text-2xl font-bold">Media Explorer</h1>
 
-      <div className="space-x-2">
-        <input
-          className="border p-1"
+      <div className="space-x-sm">
+        <Input
           value={queryWord}
           onChange={(e) => setQueryWord(e.target.value)}
           placeholder="word"
         />
-        <input
-          className="border p-1 w-16"
+        <Input
+          className="w-16"
           type="number"
           value={level}
           onChange={(e) => setLevel(Number(e.target.value))}
         />
-        <button className="px-2 py-1 bg-accent-primary text-inverse" onClick={fetchMedia}>
-          Load
-        </button>
+        <Button onClick={fetchMedia}>Load</Button>
       </div>
 
       {item && (
-        <div className="space-y-2">
-          <div className="flex space-x-2">
-            <button onClick={prev} className="px-2 py-1 bg-secondary">
+        <Card className="space-y-sm">
+          <div className="flex space-x-sm">
+            <Button onClick={prev} variant="secondary">
               Prev
-            </button>
-            <button onClick={next} className="px-2 py-1 bg-secondary">
+            </Button>
+            <Button onClick={next} variant="secondary">
               Next
-            </button>
-            <button
-              onClick={() => setShowCaptions((v) => !v)}
-              className="px-2 py-1 bg-secondary"
-            >
+            </Button>
+            <Button onClick={() => setShowCaptions((v) => !v)} variant="secondary">
               {showCaptions ? 'Hide Captions' : 'Show Captions'}
-            </button>
-            <button
-              onClick={() => setFontSize((s) => Math.max(8, s - 2))}
-              className="px-2 py-1 bg-secondary"
-            >
+            </Button>
+            <Button onClick={() => setFontSize((s) => Math.max(8, s - 2))} variant="secondary">
               A-
-            </button>
-            <button
-              onClick={() => setFontSize((s) => s + 2)}
-              className="px-2 py-1 bg-secondary"
-            >
+            </Button>
+            <Button onClick={() => setFontSize((s) => s + 2)} variant="secondary">
               A+
-            </button>
+            </Button>
           </div>
 
           {item.video && (
@@ -150,26 +141,26 @@ export default function MediaExplorer() {
               ))}
             </div>
           )}
-        </div>
+        </Card>
       )}
 
-      <div className="mt-8">
+      <div className="mt-lg">
         <h2 className="text-xl font-semibold">AI Blurb Generator</h2>
-        <div className="space-y-2">
-          <input
-            className="border p-1 w-full"
+        <Card className="space-y-sm mt-sm">
+          <Input
+            className="w-full"
             placeholder="Known words (comma separated)"
             value={knownWords}
             onChange={(e) => setKnownWords(e.target.value)}
           />
-          <input
-            className="border p-1 w-full"
+          <Input
+            className="w-full"
             placeholder="L+1 words (comma separated)"
             value={lPlusWords}
             onChange={(e) => setLPlusWords(e.target.value)}
           />
-          <div className="flex items-center space-x-2">
-            <input
+          <div className="flex items-center space-x-sm">
+            <Input
               type="range"
               min="1"
               max="50"
@@ -178,14 +169,9 @@ export default function MediaExplorer() {
             />
             <span>{blurbLength} words</span>
           </div>
-          <button
-            className="px-2 py-1 bg-accent-primary text-inverse"
-            onClick={generateBlurb}
-          >
-            Generate
-          </button>
-          {blurb && <p className="mt-2">{blurb}</p>}
-        </div>
+          <Button onClick={generateBlurb}>Generate</Button>
+          {blurb && <p className="mt-sm">{blurb}</p>}
+        </Card>
       </div>
     </div>
   );

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
 import { apiClient } from '../services/api';
+import Button from '../components/ui/Button';
+import Input from '../components/ui/Input';
+import Card from '../components/ui/Card';
 
 const TEMPLATE_TEXT = {
   books: 'Read books in your target language to expand vocabulary and comprehension.',
@@ -72,98 +75,91 @@ export default function Onboarding() {
   };
 
   return (
-    <div className="p-4">
+    <div className="p-md">
       <div aria-live="polite">
         {isLoading && <p>Loading...</p>}
         {error && <p>{error}</p>}
       </div>
       {step === 1 && (
-        <div>
-          <h1 className="text-2xl font-bold mb-4">Choose your first goal</h1>
+        <Card>
+          <h1 className="text-2xl font-bold mb-md">Choose your first goal</h1>
           <div
-            className="space-x-2 mb-2"
+            className="space-x-sm mb-sm"
             role="group"
             aria-label="Goal templates"
             aria-describedby="template-instructions"
           >
             {Object.keys(TEMPLATE_TEXT).map((name) => (
-              <button
+              <Button
                 key={name}
+                variant={template === name ? 'primary' : 'outline'}
                 onClick={() => handleTemplate(name)}
-                className={`px-3 py-1 border rounded focus:outline focus:outline-2 focus:outline-offset-2 ${
-                  template === name ? 'bg-accent-primary text-inverse' : ''
-                }`}
                 aria-label={`Use ${name} template`}
+                className="mr-sm"
               >
                 {name}
-              </button>
+              </Button>
             ))}
           </div>
-          <p id="template-instructions" className="text-sm text-gray-600 mb-4">
+          <p id="template-instructions" className="text-sm text-gray-600 mb-md">
             Use Tab to focus template buttons and Enter to select.
           </p>
-          <label htmlFor="goal-text" className="block mb-1">
+          <label htmlFor="goal-text" className="block mb-xs">
             Enter or paste your own text
           </label>
-          <textarea
+          <Input
+            as="textarea"
             id="goal-text"
             value={text}
             onChange={(e) => setText(e.target.value)}
             placeholder="Or enter your own text"
-            className="w-full border p-2 mb-2 h-40 focus:outline focus:outline-2 focus:outline-offset-2"
+            className="w-full mb-sm h-40"
           />
-          <label htmlFor="goal-file" className="block mb-1">
+          <label htmlFor="goal-file" className="block mb-xs">
             Upload a text file
           </label>
-          <input
+          <Input
             id="goal-file"
             type="file"
             accept=".txt"
             onChange={handleFile}
-            className="mb-4 focus:outline focus:outline-2 focus:outline-offset-2"
+            className="mb-md"
           />
           <div>
-            <button
-              onClick={startExtraction}
-              disabled={isLoading}
-              className="bg-accent-primary text-inverse px-4 py-2 rounded focus:outline focus:outline-2 focus:outline-offset-2"
-            >
+            <Button onClick={startExtraction} disabled={isLoading}>
               Next
-            </button>
+            </Button>
           </div>
-        </div>
+        </Card>
       )}
 
       {step === 2 && (
-        <div>
-          <h2 className="text-xl font-bold mb-4">Select words to learn</h2>
-          <ul className="mb-4">
+        <Card>
+          <h2 className="text-xl font-bold mb-md">Select words to learn</h2>
+          <ul className="mb-md">
             {vocab.map((word) => (
-              <li key={word} className="flex items-center mb-1">
+              <li key={word} className="flex items-center mb-xs">
                 <input
                   type="checkbox"
                   checked={selected.includes(word)}
                   onChange={() => toggleWord(word)}
+                  className="mr-xs"
                 />
-                <span className="ml-2">{word}</span>
+                <span>{word}</span>
               </li>
             ))}
           </ul>
-          <button
-            onClick={saveGoals}
-            disabled={isLoading}
-            className="bg-accent-primary text-inverse px-4 py-2 rounded focus:outline focus:outline-2 focus:outline-offset-2"
-          >
+          <Button onClick={saveGoals} disabled={isLoading}>
             Save Goals
-          </button>
-        </div>
+          </Button>
+        </Card>
       )}
 
       {step === 3 && (
-        <div>
-          <h2 className="text-xl font-bold mb-2">Goals saved!</h2>
+        <Card>
+          <h2 className="text-xl font-bold mb-sm">Goals saved!</h2>
           <p>You are ready to start learning.</p>
-        </div>
+        </Card>
       )}
     </div>
   );

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -16,6 +16,21 @@ module.exports = {
         "accent-secondary": "var(--accent-secondary)",
         inverse: "var(--text-inverse)",
       },
+      spacing: {
+        xs: "var(--space-xs)",
+        sm: "var(--space-sm)",
+        md: "var(--space-md)",
+        lg: "var(--space-lg)",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", "sans-serif"],
+        heading: ["var(--font-heading)", "sans-serif"],
+      },
+      fontSize: {
+        base: "var(--text-base)",
+        lg: "var(--text-lg)",
+        xl: "var(--text-xl)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add themed Button, Input, Card components for consistent UI
- replace inline elements in onboarding, media explorer, learn screens
- centralize colors, spacing, and typography tokens in Tailwind config

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689028fdf238832dbc58f86cd51a6c2b