### PR TITLE
Use top COCA words as default lesson vocabulary

### DIFF
--- a/src/language_learning/ai_lessons.py
+++ b/src/language_learning/ai_lessons.py
@@ -7,6 +7,8 @@ import random
 
 import requests
 
+from .vocabulary import get_top_coca_words
+
 
 def generate_lesson(topic: str, vocabulary: Optional[List[str]] = None) -> Dict[str, object]:
     """Return a minimal lesson plan for *topic*.
@@ -21,7 +23,7 @@ def generate_lesson(topic: str, vocabulary: Optional[List[str]] = None) -> Dict[
     lesson = {
         "topic": topic,
         "introduction": f"Today's lesson covers {topic}.",
-        "vocabulary": vocabulary or [],
+        "vocabulary": vocabulary or get_top_coca_words(),
         "exercise": f"Use {topic} in a sentence.",
     }
     return lesson

--- a/tests/test_ai_lessons.py
+++ b/tests/test_ai_lessons.py
@@ -1,10 +1,16 @@
 from language_learning.ai_lessons import generate_lesson, generate_mcq_lesson
+from language_learning.vocabulary import get_top_coca_words
 
 
 def test_generate_lesson():
     lesson = generate_lesson("food", ["apple"])
     assert lesson["topic"] == "food"
     assert "apple" in lesson["vocabulary"]
+
+
+def test_generate_lesson_defaults_to_coca_words():
+    lesson = generate_lesson("travel")
+    assert lesson["vocabulary"] == get_top_coca_words()
 
 
 def test_generate_mcq_lesson_interleaves_and_has_grammar():


### PR DESCRIPTION
## Summary
- Default lessons now populate vocabulary with the most common COCA words
- Added regression test to ensure default vocabulary leverages COCA frequencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902bbc0860832d95b395b02d8e8392