### PR TITLE
Allow default COCA words in MCQ lesson generator

### DIFF
--- a/src/language_learning/ai_lessons.py
+++ b/src/language_learning/ai_lessons.py
@@ -76,7 +76,9 @@ def _generate_distractors(word: str) -> List[str]:
 
 
 def generate_mcq_lesson(
-    topic: str, new_words: List[str], review_words: List[str]
+    topic: str,
+    new_words: list[str] | None = None,
+    review_words: list[str] | None = None,
 ) -> List[Dict[str, object]]:
     """Return a sequence of MCQ prompts and grammar micro-lessons.
 
@@ -84,8 +86,15 @@ def generate_mcq_lesson(
     and review vocabulary and simple grammar tips.  Each word yields an MCQ
     followed by a grammar hint.  ``new_words`` and ``review_words`` are
     interleaved so that learners constantly revisit prior material while
-    encountering new vocabulary.
+    encountering new vocabulary.  If either list is missing or empty,
+    ``get_top_coca_words`` is used as a fallback so the lesson always has
+    material to draw from.
     """
+
+    if not new_words:
+        new_words = get_top_coca_words()
+    if not review_words:
+        review_words = get_top_coca_words()
 
     def mcq_entry(word: str) -> Dict[str, object]:
         answer = f"meaning of {word}"

--- a/src/language_learning/api.py
+++ b/src/language_learning/api.py
@@ -29,8 +29,8 @@ class VocabularyIn(BaseModel):
 
 class LessonPromptsIn(BaseModel):
     topic: str
-    new_words: List[str] = []
-    review_words: List[str] = []
+    new_words: list[str] | None = None
+    review_words: list[str] | None = None
 
 
 class BlurbIn(BaseModel):

--- a/tests/test_ai_lessons.py
+++ b/tests/test_ai_lessons.py
@@ -40,3 +40,13 @@ def test_mcq_shuffles_and_tracks_answer():
     assert mcq["choices"][mcq["answer_index"]] == mcq["answer"]
     assert set(mcq["choices"]) == {mcq["answer"], "hola_a", "hola_b", "hola_c"}
     assert mcq["choices"] != [mcq["answer"], "hola_a", "hola_b", "hola_c"]
+
+
+def test_generate_mcq_lesson_defaults_to_coca_words():
+    lesson = generate_mcq_lesson("basics")
+    mcq_words = [item["word"] for item in lesson if item["type"] == "mcq"]
+    expected: list[str] = []
+    for w in get_top_coca_words():
+        expected.extend([w, w])
+    assert mcq_words == expected
+


### PR DESCRIPTION
## Summary
- allow `generate_mcq_lesson` to accept optional `new_words` and `review_words`
- use COCA top words when either list is missing or empty
- update API schema and add tests for these defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902cd83e74832d8a9adf24b7f84022