### PR TITLE
feat: default blurb words from COCA

### DIFF
--- a/src/language_learning/ai_blurbs.py
+++ b/src/language_learning/ai_blurbs.py
@@ -10,6 +10,8 @@ import os
 
 import requests
 
+from .vocabulary import get_top_coca_words
+
 
 def _generate_simple(
     known_words: Iterable[str],
@@ -72,12 +74,22 @@ def _generate_with_llm(
 
 
 def generate_blurb(
-    known_words: Iterable[str],
-    l_plus_one_words: Iterable[str],
+    known_words: Iterable[str] | None,
+    l_plus_one_words: Iterable[str] | None,
     length: int,
     use_llm: Optional[bool] = None,
 ) -> str:
-    """Return a short blurb using only whitelisted vocabulary."""
+    """Return a short blurb using only whitelisted vocabulary.
+
+    If both ``known_words`` and ``l_plus_one_words`` are empty, the function
+    falls back to the most common words from the COCA frequency list.
+    """
+
+    known_words = list(known_words or [])
+    l_plus_one_words = list(l_plus_one_words or [])
+    if not known_words and not l_plus_one_words:
+        known_words = get_top_coca_words()
+        l_plus_one_words = []
 
     if use_llm is None:
         use_llm = os.getenv("USE_LLM_BLURB", "").lower() in {"1", "true", "yes"}

--- a/src/language_learning/api.py
+++ b/src/language_learning/api.py
@@ -34,8 +34,8 @@ class LessonPromptsIn(BaseModel):
 
 
 class BlurbIn(BaseModel):
-    known_words: List[str] = []
-    l_plus_one_words: List[str] = []
+    known_words: List[str] | None = None
+    l_plus_one_words: List[str] | None = None
     length: int = 0
 
 

--- a/tests/test_ai_blurbs.py
+++ b/tests/test_ai_blurbs.py
@@ -1,6 +1,7 @@
 import pytest
 
 from language_learning.ai_blurbs import generate_blurb
+from language_learning.vocabulary import get_top_coca_words
 
 
 def test_generate_blurb_restricts_vocabulary():
@@ -18,3 +19,8 @@ def test_generate_blurb_length_control():
     length = 3
     blurb = generate_blurb(known, l_plus, length)
     assert len(blurb.split()) == length
+
+
+def test_generate_blurb_defaults_to_coca():
+    blurb = generate_blurb([], [], 3)
+    assert blurb.split() == get_top_coca_words(3)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 
 from language_learning.api import create_app
 from language_learning.storage import JSONStorage
+from language_learning.vocabulary import get_top_coca_words
 
 
 def _make_client(tmp_path):
@@ -52,3 +53,12 @@ def test_lesson_and_media_endpoints(tmp_path):
     assert resp.status_code == 200
     items = resp.json()
     assert items and all(item["level"] == 2 for item in items)
+
+
+def test_blurb_defaults_to_coca(tmp_path):
+    client, _ = _make_client(tmp_path)
+
+    resp = client.post("/blurb", json={"length": 3})
+    assert resp.status_code == 200
+    words = resp.json()["blurb"].split()
+    assert words == get_top_coca_words(3)


### PR DESCRIPTION
## Summary
- default blurb generation to use top COCA words when none are provided
- allow blurb API model to omit known and l+1 word lists
- test fallback behavior for generate_blurb and blurb endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68902ef1030c832d951fbc496c940903