### PR TITLE
Reduce default goal limit

### DIFF
--- a/backend/shared/database/data.ts
+++ b/backend/shared/database/data.ts
@@ -48,7 +48,7 @@ export async function saveReviewState(state: Record<string, any>) {
   );
 }
 
-// Load the default top 650 words from the bundled COCA list
+// Load the default top 5 words from the bundled COCA list
 export async function loadDefaultCocaWords(): Promise<string[]> {
   const result = runPython(
     "import json\nfrom language_learning.goals import load_default_goals\nprint(json.dumps([g.word for g in load_default_goals()]))",

--- a/src/language_learning/goals.py
+++ b/src/language_learning/goals.py
@@ -41,7 +41,7 @@ class GoalManager:
         return list(self._goals.values())
 
 
-def load_default_goals(limit: int = 650) -> Iterator[GoalItem]:
+def load_default_goals(limit: int = 5) -> Iterator[GoalItem]:
     """Yield the top ``limit`` goals from the bundled COCA frequency list."""
 
     path = Path(__file__).with_name("coca.csv")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,7 +24,7 @@ def test_goal_setup_and_persistence(tmp_path):
     assert resp.status_code == 200
     goals = resp.json()["goals"]
     assert any(g["word"] == "hello" and not g.get("is_default") for g in goals)
-    assert len(goals) == 650
+    assert len(goals) == 6
 
     with open(storage.path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
@@ -38,7 +38,7 @@ def test_create_app_loads_default_goals(tmp_path):
     resp = client.get("/goals")
     assert resp.status_code == 200
     goals = resp.json()["goals"]
-    assert len(goals) == 650
+    assert len(goals) == 5
     assert all(g.get("is_default") for g in goals)
 
 


### PR DESCRIPTION
## Summary
- Default COCA goals list now limited to top 5 entries
- Adjust tests to check for five default goals (six after adding a custom goal)
- Update backend comment about default goal seeding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68902ff29c64832da95600231746d143