### PR TITLE
docs: document COCA vocabulary fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ from language_learning import (
 )
 ```
 
+### COCA Vocabulary Fallback
+
+If no vocabulary is supplied, the modules automatically fall back to the five
+most common words from the Corpus of Contemporary American English (COCA):
+"you", "i", "the", "to", and "a". This ensures that examples and initial test
+runs always return meaningful output.
+
+```python
+from language_learning.ai_lessons import generate_lesson
+from language_learning import get_top_coca_words
+
+lesson = generate_lesson()
+print(lesson["vocabulary"])  # ['you', 'i', 'the', 'to', 'a']
+print(get_top_coca_words())   # ['you', 'i', 'the', 'to', 'a']
+```
+
 ## Running Tests
 
 This project uses [`pytest`](https://docs.pytest.org/) for its unit tests. The

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -73,6 +73,21 @@ npm run lint
 pytest
 ```
 
+## COCA Vocabulary Fallback
+
+During development, the Python modules default to the five most frequent words
+from the Corpus of Contemporary American English—"you", "i", "the", "to", and
+"a"—when no vocabulary list is supplied. This keeps demos and tests working
+even before your own data is available.
+
+```python
+from language_learning.ai_lessons import generate_lesson
+from language_learning import get_top_coca_words
+
+lesson = generate_lesson()
+assert lesson["vocabulary"] == get_top_coca_words()
+```
+
 ## CI/CD Pipeline
 
 GitHub Actions (or a similar CI service) can be configured to:


### PR DESCRIPTION
## Summary
- document automatic fallback to top five COCA words when modules run without a vocabulary
- add usage examples and rationale to README and development guide

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903591eff4832daa88646ce4c61e5f