### PR TITLE
Refactor layout to grid and simplify sidebar stats

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -20,8 +20,8 @@ export default function Layout({ children }) {
   const toggleSidebar = () => setSidebarOpen((open) => !open);
 
   return (
-    <div className="min-h-screen grid grid-rows-[auto,1fr] md:grid-cols-[16rem,1fr] grid-cols-1">
-      <header className="bg-secondary text-primary p-md flex justify-between items-center md:col-span-2">
+    <div className="min-h-screen grid grid-rows-[auto,1fr,auto]">
+      <header className="site-header">
         <div className="flex items-center space-x-lg">
           <Button
             type="button"
@@ -60,16 +60,21 @@ export default function Layout({ children }) {
           Toggle Theme
         </Button>
       </header>
-      <aside
-        className={`border-r border-white/10 p-md bg-secondary fixed inset-y-0 left-0 w-64 transform transition-transform duration-300 ease-in-out ${
-          sidebarOpen ? 'translate-x-0' : '-translate-x-full'
-        } md:static md:translate-x-0 md:w-auto md:block`}
-      >
-        <Sidebar />
-      </aside>
-      <main className="p-md overflow-y-auto">
+      <main className="page-content grid md:grid-cols-[16rem,1fr]">
+        <aside
+          className={`sidebar ${sidebarOpen ? '' : '-translate-x-full'} md:translate-x-0`}
+        >
+          <Sidebar />
+        </aside>
         <section className="skill-path">{children}</section>
       </main>
+      <footer className="site-footer">
+        <nav className="flex justify-center space-x-md">
+          <a href="#">About</a>
+          <a href="#">Contact</a>
+          <a href="#">Privacy</a>
+        </nav>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -38,16 +38,10 @@ export default function Sidebar() {
             {error}
           </p>
         )}
-        <dl className="space-y-1" aria-live="polite">
-          <div className="flex justify-between">
-            <dt>Streak</dt>
-            <dd>{stats.streak}</dd>
-          </div>
-          <div className="flex justify-between">
-            <dt>Lingots</dt>
-            <dd>{stats.lingots}</dd>
-          </div>
-        </dl>
+        <div className="space-y-1" aria-live="polite">
+          <div className="streak">🔥 {stats.streak}</div>
+          <div className="lingots">💎 {stats.lingots}</div>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -23,12 +23,11 @@ describe('Sidebar', () => {
     const { container } = render(<Sidebar />);
     expect(fetch).toHaveBeenCalledWith('/api/user/stats');
     await waitFor(() => {
-      expect(screen.getByText('Streak')).toBeInTheDocument();
-      expect(screen.getByText('3')).toBeInTheDocument();
-      expect(screen.getByText('Lingots')).toBeInTheDocument();
-      expect(screen.getByText('7')).toBeInTheDocument();
+      expect(screen.getByText('Stats')).toBeInTheDocument();
+      expect(screen.getByText('🔥 3')).toBeInTheDocument();
+      expect(screen.getByText('💎 7')).toBeInTheDocument();
     });
-    const dl = container.querySelector('dl');
-    expect(dl).toHaveAttribute('aria-live', 'polite');
+    const statsContainer = container.querySelector('[aria-live="polite"]');
+    expect(statsContainer).toBeInTheDocument();
   });
 });

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,4 +38,24 @@
   .active {
     @apply bg-white/10 text-inverse;
   }
+
+  .site-header {
+    @apply bg-secondary text-primary p-md flex justify-between items-center;
+  }
+
+  .page-content {
+    @apply w-full;
+  }
+
+  .sidebar {
+    @apply border-r border-white/10 p-md bg-secondary fixed inset-y-0 left-0 w-64 transform transition-transform duration-300 ease-in-out md:static md:w-auto md:block;
+  }
+
+  .skill-path {
+    @apply p-md overflow-y-auto;
+  }
+
+  .site-footer {
+    @apply bg-secondary text-primary p-md text-center;
+  }
 }


### PR DESCRIPTION
## Summary
- Wrap Layout in grid with header, main, and footer
- Move sidebar into main and add site footer links
- Simplify Sidebar stats display and update custom CSS utilities

## Testing
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689037353b8c832d9fa4ffb21879ca1a