### PR TITLE
feat: add tutor lesson planning

### DIFF
--- a/src/language_learning/__init__.py
+++ b/src/language_learning/__init__.py
@@ -3,6 +3,7 @@
 from .vocabulary import extract_vocabulary, get_top_coca_words
 from .spaced_repetition import SpacedRepetitionScheduler
 from .ai_lessons import generate_lesson, generate_mcq_lesson
+from .tutor import generate_tutor_lesson, select_word_batch
 from .media_integration import record_media_interaction, suggest_media
 from .ai_blurbs import generate_blurb
 
@@ -12,6 +13,8 @@ __all__ = [
     "SpacedRepetitionScheduler",
     "generate_lesson",
     "generate_mcq_lesson",
+    "generate_tutor_lesson",
+    "select_word_batch",
     "suggest_media",
     "record_media_interaction",
     "generate_blurb",

--- a/src/language_learning/tutor.py
+++ b/src/language_learning/tutor.py
@@ -1,0 +1,106 @@
+"""Lesson planning helpers combining goals and spaced repetition.
+
+This module provides a small orchestration layer that selects which
+vocabulary words to study and generates lesson items for them.  It relies on
+``SRSFilter`` to decide which words are due for review and uses goal-ranked
+vocabulary to introduce new items.  Lessons consist solely of multiple-choice
+questions with occasional grammar tips as placeholders for future
+micro-lessons.
+"""
+
+from __future__ import annotations
+
+from itertools import zip_longest
+import random
+from typing import Dict, List, Tuple
+
+from .spaced_repetition import SRSFilter
+from .ai_lessons import _generate_distractors
+
+
+def select_word_batch(
+    goal_ranked_words: List[str],
+    srs_filter: SRSFilter,
+    new_word_limit: int = 3,
+    review_limit: int = 5,
+) -> Tuple[List[str], List[str]]:
+    """Return lists of new and review words for the next lesson.
+
+    ``goal_ranked_words`` should be ordered such that earlier entries are more
+    relevant to the learner's current goal.  ``srs_filter`` tracks review
+    scheduling.  New words are those with no prior repetitions in
+    ``srs_filter`` while review words are drawn from the SRS queue based on
+    when they are due.
+    """
+
+    review_words: List[str] = []
+    seen: set[str] = set()
+    for _ in range(review_limit):
+        word = srs_filter.pop_next_due()
+        if not word or word in seen:
+            break
+        seen.add(word)
+        review_words.append(word)
+
+    new_words: List[str] = []
+    for word in goal_ranked_words:
+        if len(new_words) >= new_word_limit:
+            break
+        sched = srs_filter.schedulers.get(word)
+        if word in review_words:
+            continue
+        if not sched or sched.state.repetitions == 0:
+            new_words.append(word)
+    return new_words, review_words
+
+
+def _mcq_item(word: str) -> Dict[str, object]:
+    answer = f"meaning of {word}"
+    choices = [answer] + _generate_distractors(word)
+    random.shuffle(choices)
+    return {
+        "type": "mcq",
+        "word": word,
+        "question": f"What is the meaning of '{word}'?",
+        "choices": choices,
+        "answer": answer,
+        "answer_index": choices.index(answer),
+    }
+
+
+def _grammar_tip(word: str) -> Dict[str, str]:
+    return {
+        "type": "grammar_tip",
+        "tip": f"Remember the grammar rule associated with '{word}'.",
+    }
+
+
+def generate_tutor_lesson(
+    goal_ranked_words: List[str],
+    srs_filter: SRSFilter,
+    new_word_limit: int = 3,
+    review_limit: int = 5,
+    grammar_every: int = 10,
+) -> List[Dict[str, object]]:
+    """Generate an interleaved lesson sequence.
+
+    The function selects new and review words via :func:`select_word_batch`
+    then interleaves their multiple-choice questions.  After every
+    ``grammar_every`` new words a placeholder grammar tip is inserted.
+    """
+
+    new_words, review_words = select_word_batch(
+        goal_ranked_words, srs_filter, new_word_limit, review_limit
+    )
+
+    lesson: List[Dict[str, object]] = []
+    new_counter = 0
+    for new_word, review_word in zip_longest(new_words, review_words):
+        if new_word is not None:
+            lesson.append(_mcq_item(new_word))
+            new_counter += 1
+            if grammar_every and new_counter % grammar_every == 0:
+                lesson.append(_grammar_tip(new_word))
+        if review_word is not None:
+            lesson.append(_mcq_item(review_word))
+    return lesson

--- a/tests/test_tutor.py
+++ b/tests/test_tutor.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+
+from language_learning.tutor import select_word_batch, generate_tutor_lesson
+from language_learning.spaced_repetition import SRSFilter
+
+
+def _build_filter(words):
+    ranks = {w: i + 1 for i, w in enumerate(words)}
+    return SRSFilter(ranks)
+
+
+def test_select_word_batch_prioritises_goal_and_due():
+    goal_words = ["alpha", "beta", "gamma", "delta"]
+    filt = _build_filter(goal_words)
+    # mark gamma as a due review
+    st = filt.schedulers["gamma"].state
+    st.repetitions = 1
+    st.next_review = datetime.now() - timedelta(days=1)
+
+    new_words, review_words = select_word_batch(goal_words, filt, 2, 2)
+    assert review_words == ["gamma"]
+    assert new_words == ["alpha", "beta"]
+
+
+def test_generate_tutor_lesson_interleaves_and_inserts_grammar():
+    goal_words = ["alpha", "beta"]
+    filt = _build_filter(goal_words)
+    st = filt.schedulers["beta"].state
+    st.repetitions = 1
+    st.next_review = datetime.now() - timedelta(days=1)
+
+    lesson = generate_tutor_lesson(goal_words, filt, new_word_limit=1, review_limit=1, grammar_every=1)
+    types = [item["type"] for item in lesson]
+    assert types == ["mcq", "grammar_tip", "mcq"]
+    words = [item["word"] for item in lesson if item["type"] == "mcq"]
+    assert words == ["alpha", "beta"]


### PR DESCRIPTION
## Summary
- add tutor module that selects new and review words based on goals and SRS state
- generate lessons with interleaved MCQs and grammar tips
- expose new helpers and provide tests for selection and lesson generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689037c484e8832d8c5e777070066982