### PR TITLE
feat(frontend): add dashboard navigation buttons

### DIFF
--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -1,11 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import ProgressOverview from '../components/ProgressOverview.jsx';
+import Button from '../components/ui/Button';
+import { useNavigate } from 'react-router-dom';
 
 export default function Dashboard() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
   const [next, setNext] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+  const navigate = useNavigate();
 
   useEffect(() => {
     async function load() {
@@ -36,7 +39,13 @@ export default function Dashboard() {
       ) : error ? (
         <p>{error}</p>
       ) : (
-        <ProgressOverview heading="Dashboard" progress={progress} next={next} />
+        <>
+          <ProgressOverview heading="Dashboard" progress={progress} next={next} />
+          <div className="px-4 pb-4 mt-4 flex flex-col gap-4">
+            <Button onClick={() => navigate('/learn')}>Work with AI Tutor</Button>
+            <Button onClick={() => navigate('/media')}>Browse Media</Button>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add "Work with AI Tutor" and "Browse Media" buttons to Dashboard
- use `useNavigate` for `/learn` and `/media` routes

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903b06aec8832d9fc30419a97f4287