### PR TITLE
Set dashboard as default route and simplify navigation

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -4,14 +4,7 @@ import Sidebar from './Sidebar.jsx';
 import { useTheme } from '../context/ThemeContext.jsx';
 import Button from './ui/Button';
 
-const navItems = [
-  { path: '/', label: 'Onboarding' },
-  { path: '/dashboard', label: 'Dashboard' },
-  { path: '/learn', label: 'Learn' },
-  { path: '/media', label: 'Media' },
-  { path: '/goals', label: 'Goals' },
-  { path: '/analytics', label: 'Analytics' },
-];
+const navItems = [{ path: '/dashboard', label: 'Dashboard' }];
 
 export default function Layout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);

--- a/frontend/src/navigation/AppNavigator.jsx
+++ b/frontend/src/navigation/AppNavigator.jsx
@@ -13,7 +13,8 @@ export default function AppNavigator() {
     <Router>
       <Layout>
         <Routes>
-          <Route path="/" element={<Onboarding />} />
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/dashboard" element={<Dashboard />} />
           <Route path="/learn" element={<Learn />} />
           <Route path="/media" element={<MediaExplorer />} />


### PR DESCRIPTION
## Summary
- Show `Dashboard` by default at `/` and move `Onboarding` to `/onboarding`
- Trim header navigation down to a single Dashboard link

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903bfbab84832da85866c814eb1c0f