### PR TITLE
Document env setup and load dotenv for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ This project manages packages with `requirements.txt`. Key libraries include:
 - `requests` for media and API integration
 - `pytest` for running the test suite
 
+## Environment Configuration
+
+Backend services and Python helpers read secrets from environment variables.
+Copy `backend/.env.example` to `backend/.env` and provide values such as
+`AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, and `AZURE_OPENAI_DEPLOYMENT`.
+The frontend can load `VITE_API_URL` from `frontend/.env` (see
+`frontend/.env.example`) to point at your backend.
+
 ## Usage Examples
 
 Each module includes a small example when executed directly:

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import { createAuthService } from './services/auth';
 import { createGoalService } from './services/goal';
 import { createLessonService } from './services/lesson';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-dynamodb": "^3.614.0",
         "@aws-sdk/lib-dynamodb": "^3.614.0",
         "@prisma/client": "^5.12.0",
+        "dotenv": "^17.2.1",
         "express": "^4.18.2",
         "openai": "^4.0.0",
         "redis": "^4.6.7"
@@ -1985,6 +1986,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,18 +8,19 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "@prisma/client": "^5.12.0",
-    "express": "^4.18.2",
-    "redis": "^4.6.7",
-    "openai": "^4.0.0",
     "@aws-sdk/client-dynamodb": "^3.614.0",
-    "@aws-sdk/lib-dynamodb": "^3.614.0"
+    "@aws-sdk/lib-dynamodb": "^3.614.0",
+    "@prisma/client": "^5.12.0",
+    "dotenv": "^17.2.1",
+    "express": "^4.18.2",
+    "openai": "^4.0.0",
+    "redis": "^4.6.7"
   },
   "devDependencies": {
+    "@types/express": "^4.17.21",
     "prisma": "^5.12.0",
-    "typescript": "^5.4.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "@types/express": "^4.17.21"
+    "typescript": "^5.4.0"
   }
 }

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -35,12 +35,29 @@ cd frontend
 npm install
 ```
 
-### 3. Start Docker services
+### 3. Configure environment variables
+
+Copy the example files and provide your own API keys and service endpoints:
+
+```bash
+cp backend/.env.example backend/.env
+# edit backend/.env and set AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT, etc.
+```
+
+Optionally create a `.env` file for the frontend if you need to override
+`VITE_API_URL`:
+
+```bash
+cp frontend/.env.example frontend/.env
+# edit frontend/.env to point to your backend URL
+```
+
+### 4. Start Docker services
 ```bash
 docker-compose up -d
 ```
 
-### 4. Run development servers
+### 5. Run development servers
 
 **Backend**
 ```bash


### PR DESCRIPTION
## Summary
- document how to configure env vars in README and development guide
- load backend environment variables from `.env` via dotenv

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903d3ee6e4832db2ea67124577c145