### PR TITLE
Enable standalone API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ To get started, you will need:
 - Python 3.10+
 - `pip` for managing packages
 
-Create a virtual environment and install dependencies:
+Create a virtual environment and install dependencies. The project now ships a
+`pyproject.toml` so the package can be installed in editable mode:
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # On Windows use: .venv\Scripts\activate
 pip install -r requirements.txt
+pip install -e .
 ```
 
 ### Dependencies
@@ -51,11 +53,18 @@ The frontend can load `VITE_API_URL` from `frontend/.env` (see
 Each module includes a small example when executed directly:
 
 ```bash
-PYTHONPATH=src python -m language_learning.vocabulary
-PYTHONPATH=src python -m language_learning.spaced_repetition
-PYTHONPATH=src python -m language_learning.ai_lessons
-PYTHONPATH=src python -m language_learning.media_integration
+python -m language_learning.vocabulary
+python -m language_learning.spaced_repetition
+python -m language_learning.ai_lessons
+python -m language_learning.media_integration
 ```
+
+To try the FastAPI service locally, run:
+
+```bash
+python -m language_learning.api
+```
+This uses `uvicorn` under the hood and serves the API on http://localhost:8000 by default.
 
 You can also import the modules in your own scripts:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "language-learning"
+version = "0.1.0"
+description = "LanguageLearning core modules"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=1.0.0",
+    "nltk>=3.8",
+    "spacy>=3.7",
+    "requests>=2.31",
+    "pytest>=7.4",
+    "fastapi>=0.110",
+    "uvicorn>=0.29",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["language_learning"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"language_learning" = ["coca.csv"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ spacy>=3.7
 requests>=2.31
 pytest>=7.4
 fastapi>=0.110
+uvicorn>=0.29

--- a/src/language_learning/api.py
+++ b/src/language_learning/api.py
@@ -115,3 +115,13 @@ def create_app(storage: Optional[JSONStorage] = None) -> FastAPI:
 
 
 app = create_app()
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(
+        "language_learning.api:app",
+        host="0.0.0.0",
+        port=int(os.environ.get("PORT", 8000)),
+    )


### PR DESCRIPTION
## Summary
- allow running FastAPI module directly with uvicorn
- document editable install and CLI usage
- add packaging metadata and uvicorn dependency

## Testing
- `pip install uvicorn`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ac542f04832d98aeed920eb19668