### PR TITLE
Remove invalid CSS references causing 403

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -63,10 +63,6 @@
       }]);
     </script>
 
-    <!-- Core CSS bundles -->
-    <link href="/css/6458-acfd0c45.css" rel="stylesheet">
-    <link href="/css/app-0b29a805.css" rel="stylesheet">
-
     <!-- Title & meta description/keywords -->
     <title>Language Learning – Learn a language for free</title>
     <meta name="description" content="Language Learning is a fun way to practice languages.">


### PR DESCRIPTION
## Summary
- remove outdated hashed CSS bundle links from index.html

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890c2a7ef24832d97fa70b55eec9720