### PR TITLE
feat: add styled button variants

### DIFF
--- a/frontend/src/components/ui/Button.jsx
+++ b/frontend/src/components/ui/Button.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-const base = 'px-md py-sm rounded focus:outline focus:outline-2 focus:outline-offset-2';
+const base = 'focus:outline focus:outline-2 focus:outline-offset-2';
 const variants = {
-  primary: 'bg-primary text-text',
-  secondary: 'bg-success text-inverse',
+  primary: 'button-primary',
+  secondary: 'button-secondary',
   outline: 'border',
 };
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,4 +94,34 @@
   .site-footer {
     @apply bg-surface text-text p-md text-center;
   }
+
+  .button-primary {
+    font-weight: 600;
+    background-color: #FFBF32;
+    color: #0F0F0F;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    transition: transform 0.2s;
+  }
+
+  .button-primary:hover,
+  .button-primary:focus {
+    text-decoration: underline;
+    transform: scale(1.05);
+  }
+
+  .button-secondary {
+    font-weight: 600;
+    background-color: #529917;
+    color: #FFFFFF;
+    border-radius: 0.5rem;
+    padding: 0.75rem 1.5rem;
+    transition: transform 0.2s;
+  }
+
+  .button-secondary:hover,
+  .button-secondary:focus {
+    text-decoration: underline;
+    transform: scale(1.05);
+  }
 }


### PR DESCRIPTION
## Summary
- define `.button-primary` and `.button-secondary` styles with guide-compliant colors and transitions
- refactor `Button` component to use new classes for primary/secondary variants

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ce708b20832dad1823eca8fecda3