### PR TITLE
feat: style cards with secondary button

### DIFF
--- a/frontend/src/components/ui/Card.jsx
+++ b/frontend/src/components/ui/Card.jsx
@@ -1,6 +1,18 @@
 import React from 'react';
+import Button from './Button';
 
-export default function Card({ className = '', ...props }) {
-  const base = 'bg-surface text-text rounded shadow p-md';
-  return <div className={`${base} ${className}`} {...props} />;
+function Card({ className = '', children, ...props }) {
+  const base =
+    'bg-white border border-[#E5F9CE] rounded-[0.75rem] p-[1.5rem] text-[#5D5D5D] [&_h1]:font-semibold [&_h1]:text-[#072F45] [&_h2]:font-semibold [&_h2]:text-[#072F45] [&_h3]:font-semibold [&_h3]:text-[#072F45]';
+  return (
+    <div className={`${base} ${className}`} {...props}>
+      {children}
+    </div>
+  );
 }
+
+Card.Button = function CardButton({ className = '', ...props }) {
+  return <Button variant="secondary" className={className} {...props} />;
+};
+
+export default Card;

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -80,9 +80,9 @@ export default function Onboarding() {
         {isLoading && <p>Loading...</p>}
         {error && <p>{error}</p>}
       </div>
-      {step === 1 && (
+        {step === 1 && (
         <Card>
-          <h1 className="text-2xl font-bold mb-md">Choose your first goal</h1>
+          <h1 className="text-2xl mb-md">Choose your first goal</h1>
           <div
             className="space-x-sm mb-sm"
             role="group"
@@ -133,9 +133,9 @@ export default function Onboarding() {
         </Card>
       )}
 
-      {step === 2 && (
+        {step === 2 && (
         <Card>
-          <h2 className="text-xl font-bold mb-md">Select words to learn</h2>
+          <h2 className="text-xl mb-md">Select words to learn</h2>
           <ul className="mb-md">
             {vocab.map((word) => (
               <li key={word} className="flex items-center mb-xs">
@@ -155,10 +155,11 @@ export default function Onboarding() {
         </Card>
       )}
 
-      {step === 3 && (
+        {step === 3 && (
         <Card>
-          <h2 className="text-xl font-bold mb-sm">Goals saved!</h2>
+          <h2 className="mb-sm">Goals saved!</h2>
           <p>You are ready to start learning.</p>
+          <Card.Button className="mt-md">Start Learning</Card.Button>
         </Card>
       )}
     </div>


### PR DESCRIPTION
## Summary
- restyle Card component with white background, border and heading styling
- add Card.Button helper and use on onboarding completion step

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890d253a120832db4674d5d93430117