### PR TITLE
Fix analytics API base for dashboard

### DIFF
--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ProgressOverview from '../components/ProgressOverview.jsx';
 import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
+import { apiClient } from '../services/api.js';
 
 export default function Dashboard() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
@@ -15,12 +16,10 @@ export default function Dashboard() {
       try {
         setIsLoading(true);
         setError(null);
-        const [progressRes, nextRes] = await Promise.all([
-          fetch('/analytics/progress'),
-          fetch('/analytics/reviews/next'),
+        const [progressData, nextData] = await Promise.all([
+          apiClient('/analytics/progress'),
+          apiClient('/analytics/reviews/next'),
         ]);
-        const progressData = await progressRes.json();
-        const nextData = await nextRes.json();
         setProgress(progressData);
         setNext(nextData.next || []);
       } catch (err) {

--- a/frontend/src/screens/Dashboard.test.jsx
+++ b/frontend/src/screens/Dashboard.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import Dashboard from './Dashboard.jsx';
+import { MemoryRouter } from 'react-router-dom';
+
+expect.extend(matchers);
+
+describe('Dashboard', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ learned: 1, total: 2 }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ next: ['alpha', 'beta'] }),
+        })
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  test('loads progress and next review words', async () => {
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/analytics/progress',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/analytics/reviews/next',
+      expect.objectContaining({ method: 'GET' })
+    );
+    await waitFor(() => {
+      expect(screen.getByText('1/2')).toBeInTheDocument();
+      expect(screen.getByText('alpha')).toBeInTheDocument();
+      expect(screen.getByText('beta')).toBeInTheDocument();
+    });
+  });
+
+  test('shows error when requests fail', async () => {
+    fetch.mockReset();
+    fetch
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ next: [] }),
+      });
+    render(
+      <MemoryRouter>
+        <Dashboard />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(
+        screen.getByText('Unable to load dashboard data.')
+      ).toBeInTheDocument();
+    });
+  });
+});
+

--- a/frontend/src/screens/GoalView.jsx
+++ b/frontend/src/screens/GoalView.jsx
@@ -1,17 +1,16 @@
 import React, { useEffect, useState } from 'react';
 import ProgressOverview from '../components/ProgressOverview.jsx';
+import { apiClient } from '../services/api.js';
 
 export default function GoalView() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
   const [next, setNext] = useState([]);
 
   useEffect(() => {
-    fetch('/analytics/progress')
-      .then((r) => r.json())
+    apiClient('/analytics/progress')
       .then((data) => setProgress(data))
       .catch(() => {});
-    fetch('/analytics/reviews/next')
-      .then((r) => r.json())
+    apiClient('/analytics/reviews/next')
       .then((data) => setNext(data.next || []))
       .catch(() => {});
   }, []);


### PR DESCRIPTION
## Summary
- fetch dashboard analytics via shared API client to use `/api` prefix
- cover dashboard load and error states with frontend tests

## Testing
- `npm --prefix frontend test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890dc49f710832daba8f08d6df2e5c1