### PR TITLE
feat: add skip link to main content

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -14,6 +14,12 @@ export default function Layout({ children }) {
 
   return (
     <div className="min-h-screen grid grid-rows-[auto,1fr,auto]">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:bg-white focus:text-primary focus:px-s focus:py-xs focus:rounded"
+      >
+        Skip to main content
+      </a>
       <header className="site-header">
         <div className="flex items-center space-x-m">
           <Button
@@ -71,7 +77,10 @@ export default function Layout({ children }) {
           onClose={() => setSettingsOpen(false)}
         />
       )}
-      <main className="page-content grid md:grid-cols-[16rem,1fr]">
+      <main
+        id="main-content"
+        className="page-content grid md:grid-cols-[16rem,1fr]"
+      >
         <aside
           className={`sidebar ${sidebarOpen ? '' : '-translate-x-full'} md:translate-x-0`}
         >


### PR DESCRIPTION
## Summary
- add visually hidden skip link for quick access to main content
- tag main content container with matching `id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890e215a120832da59120d7e509ee8e