### PR TITLE
Add goal management UI and tests

### DIFF
--- a/frontend/src/screens/GoalView.jsx
+++ b/frontend/src/screens/GoalView.jsx
@@ -1,19 +1,74 @@
 import React, { useEffect, useState } from 'react';
-import ProgressOverview from '../components/ProgressOverview.jsx';
-import { apiClient } from '../services/api.js';
+import { fetchGoals, addGoal, deleteGoal } from '../services/api.js';
 
 export default function GoalView() {
-  const [progress, setProgress] = useState({ learned: 0, total: 0 });
-  const [next, setNext] = useState([]);
+  const [goals, setGoals] = useState([]);
+  const [showInput, setShowInput] = useState(false);
+  const [newWord, setNewWord] = useState('');
+
+  const loadGoals = () => {
+    fetchGoals()
+      .then((data) => setGoals(data.goals || []))
+      .catch(() => {});
+  };
 
   useEffect(() => {
-    apiClient('/analytics/progress')
-      .then((data) => setProgress(data))
-      .catch(() => {});
-    apiClient('/analytics/reviews/next')
-      .then((data) => setNext(data.next || []))
-      .catch(() => {});
+    loadGoals();
   }, []);
 
-  return <ProgressOverview heading="Goal View" progress={progress} next={next} />;
+  const handleAdd = async () => {
+    if (!newWord.trim()) return;
+    await addGoal(newWord.trim());
+    setNewWord('');
+    setShowInput(false);
+    loadGoals();
+  };
+
+  const handleDelete = async (word) => {
+    await deleteGoal(word);
+    loadGoals();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Goals</h1>
+      <ul>
+        {goals.map((g) => (
+          <li key={g.word} className="mb-2 flex items-center gap-2">
+            <span>{g.word}</span>
+            {g.is_default && <span className="text-gray-500">(default)</span>}
+            <button
+              className="ml-auto text-red-500"
+              onClick={() => handleDelete(g.word)}
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+      </ul>
+      {showInput ? (
+        <div className="mt-4 flex items-center gap-2">
+          <input
+            value={newWord}
+            onChange={(e) => setNewWord(e.target.value)}
+            placeholder="Add a word"
+            className="border p-1"
+          />
+          <button
+            className="bg-blue-500 text-white px-2 py-1"
+            onClick={handleAdd}
+          >
+            Add
+          </button>
+        </div>
+      ) : (
+        <button
+          className="mt-4 bg-blue-500 text-white px-2 py-1"
+          onClick={() => setShowInput(true)}
+        >
+          Add Goal
+        </button>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/screens/GoalView.test.jsx
+++ b/frontend/src/screens/GoalView.test.jsx
@@ -1,0 +1,115 @@
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  cleanup,
+} from '@testing-library/react';
+import {
+  describe,
+  test,
+  expect,
+  vi,
+  afterEach,
+} from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import GoalView from './GoalView.jsx';
+import { MemoryRouter } from 'react-router-dom';
+
+expect.extend(matchers);
+
+describe('GoalView', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  test('COCA defaults appear on initial load', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({ goals: [{ word: 'alpha', is_default: true }] }),
+      })
+    );
+    render(
+      <MemoryRouter>
+        <GoalView />
+      </MemoryRouter>
+    );
+    await waitFor(() => {
+      expect(screen.getByText('alpha')).toBeInTheDocument();
+      expect(screen.getByText('(default)')).toBeInTheDocument();
+    });
+  });
+
+  test('"Remove" deletes a goal', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ goals: [{ word: 'alpha' }] }),
+        })
+        .mockResolvedValueOnce({ ok: true, status: 204 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ goals: [] }),
+        })
+    );
+    render(
+      <MemoryRouter>
+        <GoalView />
+      </MemoryRouter>
+    );
+    await waitFor(() => screen.getByText('alpha'));
+    fireEvent.click(screen.getByRole('button', { name: /remove/i }));
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/goals/alpha',
+        expect.objectContaining({ method: 'DELETE' })
+      );
+      expect(screen.queryByText('alpha')).not.toBeInTheDocument();
+    });
+  });
+
+  test('"Add Goal" posts a new word and updates the list', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi
+        .fn()
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ goals: [] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ goals: [{ word: 'beta' }] }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ goals: [{ word: 'beta' }] }),
+        })
+    );
+    render(
+      <MemoryRouter>
+        <GoalView />
+      </MemoryRouter>
+    );
+    fireEvent.click(screen.getByText('Add Goal'));
+    fireEvent.change(screen.getByPlaceholderText('Add a word'), {
+      target: { value: 'beta' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/ }));
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/goals',
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(screen.getByText('beta')).toBeInTheDocument();
+    });
+  });
+});
+

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -15,6 +15,9 @@ export async function apiClient(endpoint, { method = 'GET', body, headers } = {}
     const text = await response.text();
     throw new Error(text || 'API request failed');
   }
+  if (response.status === 204) {
+    return null;
+  }
   return response.json();
 }
 
@@ -43,3 +46,14 @@ export const generateBlurb = (
       length,
     },
   });
+
+export const fetchGoals = () => apiClient('/goals');
+
+export const addGoal = (word, weight) =>
+  apiClient('/goals', {
+    method: 'POST',
+    body: { word, ...(weight ? { weight } : {}) },
+  });
+
+export const deleteGoal = (word) =>
+  apiClient(`/goals/${encodeURIComponent(word)}`, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
- add API helpers for goal CRUD operations
- redesign GoalView to list, add, and remove goals with default labeling
- test GoalView to ensure default goals render and add/remove work

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e43bff84832dbc38f5bee164885f