### PR TITLE
Wrap step 2 word checkboxes in label

### DIFF
--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -137,15 +137,18 @@ export default function Onboarding() {
         <Card>
           <h2 className="text-xl mb-s">Select words to learn</h2>
           <ul className="mb-s">
-            {vocab.map((word) => (
-              <li key={word} className="flex items-center mb-xxs">
-                <input
-                  type="checkbox"
-                  checked={selected.includes(word)}
-                  onChange={() => toggleWord(word)}
-                  className="mr-xxs"
-                />
-                <span>{word}</span>
+            {vocab.map((word, idx) => (
+              <li key={word} className="mb-xxs">
+                <label htmlFor={`word-${idx}`} className="flex items-center">
+                  <input
+                    id={`word-${idx}`}
+                    type="checkbox"
+                    checked={selected.includes(word)}
+                    onChange={() => toggleWord(word)}
+                    className="mr-xxs"
+                  />
+                  {word}
+                </label>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- wrap step 2 vocabulary checkboxes with labels so clicking word toggles selection

## Testing
- `npm --prefix frontend test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890e9ad29f0832d8163271dcf826b31