### PR TITLE
Move Dashboard link to sidebar

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,10 +1,7 @@
 import React, { useState } from 'react';
-import { NavLink } from 'react-router-dom';
 import Sidebar from './Sidebar.jsx';
 import Button from './ui/Button';
 import UserSettings from './UserSettings.jsx';
-
-const navItems = [{ path: '/dashboard', label: 'Dashboard' }];
 
 export default function Layout({ children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -21,7 +18,7 @@ export default function Layout({ children }) {
         Skip to main content
       </a>
       <header className="site-header">
-        <div className="flex items-center space-x-m">
+        <div className="flex items-center">
           <Button
             type="button"
             onClick={toggleSidebar}
@@ -34,21 +31,6 @@ export default function Layout({ children }) {
             <span className="block w-6 h-0.5 bg-current my-1" />
             <span className="block w-6 h-0.5 bg-current" />
           </Button>
-          <nav className="flex space-x-m">
-            {navItems.map((item) => (
-              <NavLink
-                key={item.path}
-                to={item.path}
-                className={({ isActive }) =>
-                  `px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
-                    isActive ? 'active' : ''
-                  }`
-                }
-              >
-                {item.label}
-              </NavLink>
-            ))}
-          </nav>
         </div>
         <Button
           type="button"

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -36,6 +36,18 @@ export default function Sidebar() {
         <ul className="space-y-2">
           <li>
             <NavLink
+              to="/dashboard"
+              className={({ isActive }) =>
+                `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  isActive ? 'active' : ''
+                }`
+              }
+            >
+              Dashboard
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
               to="/onboarding"
               className={({ isActive }) =>
                 `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -43,6 +43,7 @@ describe('Sidebar', () => {
         <Sidebar />
       </MemoryRouter>
     );
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /onboarding/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /goals/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /analytics/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- Add Dashboard link to sidebar navigation
- Remove unused header navigation in Layout
- Update Sidebar tests for new Dashboard link

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890ee4932e4832d9bdedff72cb84d04