### PR TITLE
Add vocabulary screen and sidebar navigation

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -60,6 +60,18 @@ export default function Sidebar() {
           </li>
           <li>
             <NavLink
+              to="/vocabulary"
+              className={({ isActive }) =>
+                `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  isActive ? 'active' : ''
+                }`
+              }
+            >
+              Vocabulary
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
               to="/analytics"
               className={({ isActive }) =>
                 `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -45,6 +45,18 @@ describe('Sidebar', () => {
     );
     expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /goals/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /vocabulary/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /analytics/i })).toBeInTheDocument();
+  });
+
+  test('includes link to vocabulary page', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+    const vocabLink = screen.getByRole('link', { name: /vocabulary/i });
+    expect(vocabLink).toBeInTheDocument();
+    expect(vocabLink).toHaveAttribute('href', '/vocabulary');
   });
 });

--- a/frontend/src/navigation/AppNavigator.jsx
+++ b/frontend/src/navigation/AppNavigator.jsx
@@ -7,6 +7,7 @@ import Learn from '../screens/Learn.jsx';
 import MediaExplorer from '../screens/MediaExplorer.jsx';
 import GoalView from '../screens/GoalView.jsx';
 import Analytics from '../screens/Analytics.jsx';
+import MyVocabulary from '../screens/MyVocabulary.jsx';
 
 export default function AppNavigator() {
   return (
@@ -19,6 +20,7 @@ export default function AppNavigator() {
           <Route path="/learn" element={<Learn />} />
           <Route path="/media" element={<MediaExplorer />} />
           <Route path="/goals" element={<GoalView />} />
+          <Route path="/vocabulary" element={<MyVocabulary />} />
           <Route path="/analytics" element={<Analytics />} />
         </Routes>
       </Layout>

--- a/frontend/src/screens/MyVocabulary.jsx
+++ b/frontend/src/screens/MyVocabulary.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function MyVocabulary() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">My Vocabulary</h1>
+      <p className="mt-2">Your saved words will appear here.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add MyVocabulary screen
- register /vocabulary route
- expose Vocabulary link in sidebar
- test sidebar vocabulary link

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f3ac0298832d8c2279992e785814