### PR TITLE
Embed analytics in dashboard and drop route

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -70,18 +70,6 @@ export default function Sidebar() {
               Vocabulary
             </NavLink>
           </li>
-          <li>
-            <NavLink
-              to="/analytics"
-              className={({ isActive }) =>
-                `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
-                  isActive ? 'active' : ''
-                }`
-              }
-            >
-              Analytics
-            </NavLink>
-          </li>
         </ul>
       </nav>
       <div>

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -46,7 +46,7 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /goals/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /vocabulary/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /analytics/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /analytics/i })).not.toBeInTheDocument();
   });
 
   test('includes link to vocabulary page', () => {

--- a/frontend/src/navigation/AppNavigator.jsx
+++ b/frontend/src/navigation/AppNavigator.jsx
@@ -6,7 +6,6 @@ import Dashboard from '../screens/Dashboard.jsx';
 import Learn from '../screens/Learn.jsx';
 import MediaExplorer from '../screens/MediaExplorer.jsx';
 import GoalView from '../screens/GoalView.jsx';
-import Analytics from '../screens/Analytics.jsx';
 import MyVocabulary from '../screens/MyVocabulary.jsx';
 
 export default function AppNavigator() {
@@ -21,7 +20,6 @@ export default function AppNavigator() {
           <Route path="/media" element={<MediaExplorer />} />
           <Route path="/goals" element={<GoalView />} />
           <Route path="/vocabulary" element={<MyVocabulary />} />
-          <Route path="/analytics" element={<Analytics />} />
         </Routes>
       </Layout>
     </Router>

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -3,6 +3,7 @@ import ProgressOverview from '../components/ProgressOverview.jsx';
 import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../services/api.js';
+import Analytics from './Analytics.jsx';
 
 export default function Dashboard() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
@@ -44,6 +45,7 @@ export default function Dashboard() {
             <Button onClick={() => navigate('/learn')}>Work with AI Tutor</Button>
             <Button onClick={() => navigate('/media')}>Browse Media</Button>
           </div>
+          <Analytics />
         </>
       )}
     </div>


### PR DESCRIPTION
## Summary
- remove dedicated analytics route and sidebar entry
- render analytics component within the dashboard screen
- update sidebar tests for new navigation

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f69d1ee0832d8155d6764b5df9e2