### PR TITLE
Rename GoalSpeak doc to FluentMilestoneGuidelines

### DIFF
--- a/docs/FluentMilestoneGuidelines.md
+++ b/docs/FluentMilestoneGuidelines.md
@@ -1,4 +1,4 @@
-# GoalSpeak: AI-Powered, Goal-Driven Language Learning
+# Fluent Milestone Guidelines: AI-Powered, Goal-Driven Language Learning
 
 A reference overview of key business, product and technical details—meant to live alongside your code in the repo.
 


### PR DESCRIPTION
## Summary
- rename GOALSPEAK documentation to FluentMilestoneGuidelines
- update document title to reflect new name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f825ce44832daa46d7f49c1bc45f