### PR TITLE
feat: add tutor and media library links to sidebar

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -70,6 +70,30 @@ export default function Sidebar() {
               Vocabulary
             </NavLink>
           </li>
+          <li>
+            <NavLink
+              to="/learn"
+              className={({ isActive }) =>
+                `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  isActive ? 'active' : ''
+                }`
+              }
+            >
+              Tutor
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/media"
+              className={({ isActive }) =>
+                `block px-xs py-xxs rounded hover:bg-white/5 focus:bg-white/5 focus:outline-none ${
+                  isActive ? 'active' : ''
+                }`
+              }
+            >
+              Media Library
+            </NavLink>
+          </li>
         </ul>
       </nav>
       <div>

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -46,6 +46,10 @@ describe('Sidebar', () => {
     expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /goals/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /vocabulary/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /tutor/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /media library/i })
+    ).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /analytics/i })).not.toBeInTheDocument();
   });
 
@@ -58,5 +62,27 @@ describe('Sidebar', () => {
     const vocabLink = screen.getByRole('link', { name: /vocabulary/i });
     expect(vocabLink).toBeInTheDocument();
     expect(vocabLink).toHaveAttribute('href', '/vocabulary');
+  });
+
+  test('includes link to tutor page', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+    const tutorLink = screen.getByRole('link', { name: /tutor/i });
+    expect(tutorLink).toBeInTheDocument();
+    expect(tutorLink).toHaveAttribute('href', '/learn');
+  });
+
+  test('includes link to media library page', () => {
+    render(
+      <MemoryRouter>
+        <Sidebar />
+      </MemoryRouter>
+    );
+    const mediaLink = screen.getByRole('link', { name: /media library/i });
+    expect(mediaLink).toBeInTheDocument();
+    expect(mediaLink).toHaveAttribute('href', '/media');
   });
 });


### PR DESCRIPTION
## Summary
- add Tutor and Media Library navigation links to sidebar
- test presence of new links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890f842f25c832daf9f3c57f01cfafc