### PR TITLE
feat(frontend): add dark theme variables

### DIFF
--- a/frontend/src/context/ThemeContext.test.jsx
+++ b/frontend/src/context/ThemeContext.test.jsx
@@ -1,0 +1,47 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import { ThemeProvider, useTheme } from './ThemeContext.jsx';
+
+expect.extend(matchers);
+
+function ThemeToggleButton() {
+  const { toggleTheme } = useTheme();
+  return <button onClick={toggleTheme}>Toggle</button>;
+}
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
+    const style = document.createElement('style');
+    style.innerHTML = `
+      :root { --color-bg: #F6F6F6; }
+      [data-theme='dark'] { --color-bg: #121212; }
+    `;
+    document.head.appendChild(style);
+  });
+
+  test('toggleTheme updates data-theme attribute and CSS variables', async () => {
+    render(
+      <ThemeProvider>
+        <ThemeToggleButton />
+      </ThemeProvider>
+    );
+    const html = document.documentElement;
+
+    await waitFor(() => expect(html.getAttribute('data-theme')).toBe('light'));
+    const lightBg = getComputedStyle(html).getPropertyValue('--color-bg').trim();
+    expect(lightBg).toBe('#F6F6F6');
+
+    screen.getByText('Toggle').click();
+
+    await waitFor(() => expect(html.getAttribute('data-theme')).toBe('dark'));
+    const darkBg = getComputedStyle(html).getPropertyValue('--color-bg').trim();
+    expect(darkBg).toBe('#121212');
+  });
+});

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -33,6 +33,27 @@
   --color-success: #529917;
   --color-danger: #C53030;
   --color-inverse: #FFFFFF;
+  --button-primary-bg: var(--color-primary);
+  --button-primary-text: #0F0F0F;
+  --button-secondary-bg: var(--color-success);
+  --button-secondary-text: #FFFFFF;
+}
+
+[data-theme='dark'] {
+  --color-primary: #FFBF32;
+  --color-primary-light: #665500;
+  --color-accent: #1EC6F2;
+  --color-bg: #121212;
+  --color-surface: #1F1F1F;
+  --color-text-primary: #E0E0E0;
+  --color-text-secondary: #A3A3A3;
+  --color-success: #74C476;
+  --color-danger: #E53E3E;
+  --color-inverse: #0F0F0F;
+  --button-primary-bg: var(--color-primary);
+  --button-primary-text: #0F0F0F;
+  --button-secondary-bg: var(--color-success);
+  --button-secondary-text: #FFFFFF;
 }
 
 @layer base {
@@ -110,8 +131,8 @@
 
   .button-primary {
     font-weight: 600;
-    background-color: #FFBF32;
-    color: #0F0F0F;
+    background-color: var(--button-primary-bg);
+    color: var(--button-primary-text);
     border-radius: 0.5rem;
     padding: 0.75rem 1.5rem;
     transition: transform 0.2s;
@@ -125,8 +146,8 @@
 
   .button-secondary {
     font-weight: 600;
-    background-color: #529917;
-    color: #FFFFFF;
+    background-color: var(--button-secondary-bg);
+    color: var(--button-secondary-text);
     border-radius: 0.5rem;
     padding: 0.75rem 1.5rem;
     transition: transform 0.2s;


### PR DESCRIPTION
## Summary
- add `[data-theme='dark']` variables to support dark mode
- refactor button styles to use theme variables
- test ThemeContext toggling updates `data-theme` and CSS variables

## Testing
- `cd frontend && npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890fedcc814832d811de85b3a7231b0