### PR TITLE
feat(frontend): add NotFound screen and route

### DIFF
--- a/frontend/src/navigation/AppNavigator.jsx
+++ b/frontend/src/navigation/AppNavigator.jsx
@@ -7,6 +7,7 @@ import Learn from '../screens/Learn.jsx';
 import MediaExplorer from '../screens/MediaExplorer.jsx';
 import GoalView from '../screens/GoalView.jsx';
 import MyVocabulary from '../screens/MyVocabulary.jsx';
+import NotFound from '../screens/NotFound.jsx';
 
 export default function AppNavigator() {
   return (
@@ -20,6 +21,7 @@ export default function AppNavigator() {
           <Route path="/media" element={<MediaExplorer />} />
           <Route path="/goals" element={<GoalView />} />
           <Route path="/vocabulary" element={<MyVocabulary />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
       </Layout>
     </Router>

--- a/frontend/src/screens/NotFound.jsx
+++ b/frontend/src/screens/NotFound.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import Button from '../components/ui/Button';
+
+export default function NotFound() {
+  const navigate = useNavigate();
+  return (
+    <div className="p-s text-center">
+      <h1 className="text-2xl mb-s">Page not found</h1>
+      <Button onClick={() => navigate('/dashboard')}>Go to Dashboard</Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple NotFound screen with link back to the dashboard
- wire up a wildcard NotFound route in the app navigator

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689104424134832d8aaef59711192c2e