### PR TITLE
feat: add status message component

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import StatusMessage from './StatusMessage.jsx';
 
 export default function Sidebar() {
   const [stats, setStats] = useState({ streak: 0, lingots: 0 });
@@ -98,11 +99,7 @@ export default function Sidebar() {
       </nav>
       <div>
         <h2 className="font-bold">Stats</h2>
-        {error && (
-          <p role="alert" className="text-red-500">
-            {error}
-          </p>
-        )}
+        {error && <StatusMessage type="error" message={error} />}
         <div className="space-y-1" aria-live="polite">
           <div className="streak">🔥 {stats.streak}</div>
           <div className="lingots">💎 {stats.lingots}</div>

--- a/frontend/src/components/StatusMessage.jsx
+++ b/frontend/src/components/StatusMessage.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function StatusMessage({ type = 'loading', message }) {
+  const role = type === 'error' ? 'alert' : 'status';
+  const styles =
+    type === 'error' ? 'text-red-500' : 'text-gray-600';
+  return (
+    <p role={role} className={styles}>
+      {message}
+    </p>
+  );
+}

--- a/frontend/src/components/StatusMessage.test.jsx
+++ b/frontend/src/components/StatusMessage.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, test, expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+import StatusMessage from './StatusMessage.jsx';
+
+expect.extend(matchers);
+
+describe('StatusMessage', () => {
+  test('renders loading message with status role', () => {
+    render(<StatusMessage type="loading" message="Loading..." />);
+    const msg = screen.getByText('Loading...');
+    expect(msg).toHaveAttribute('role', 'status');
+  });
+
+  test('renders error message with alert role', () => {
+    render(<StatusMessage type="error" message="Error!" />);
+    const msg = screen.getByRole('alert');
+    expect(msg).toHaveTextContent('Error!');
+  });
+});

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -4,6 +4,7 @@ import Button from '../components/ui/Button';
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../services/api.js';
 import Analytics from './Analytics.jsx';
+import StatusMessage from '../components/StatusMessage.jsx';
 
 export default function Dashboard() {
   const [progress, setProgress] = useState({ learned: 0, total: 0 });
@@ -33,11 +34,11 @@ export default function Dashboard() {
   }, []);
 
   return (
-    <div aria-live="polite">
+    <div>
       {isLoading ? (
-        <p>Loading...</p>
+        <StatusMessage type="loading" message="Loading..." />
       ) : error ? (
-        <p>{error}</p>
+        <StatusMessage type="error" message={error} />
       ) : (
         <>
           <ProgressOverview heading="Dashboard" progress={progress} next={next} />

--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -3,6 +3,7 @@ import { apiClient } from '../services/api';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Card from '../components/ui/Card';
+import StatusMessage from '../components/StatusMessage.jsx';
 
 export default function Learn() {
   const [queue, setQueue] = useState([]);
@@ -103,16 +104,16 @@ export default function Learn() {
 
   if (isLoading) {
     return (
-      <div className="p-s" aria-live="polite">
-        <p>Loading...</p>
+      <div className="p-s">
+        <StatusMessage type="loading" message="Loading..." />
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-s" aria-live="polite">
-        <p>{error}</p>
+      <div className="p-s">
+        <StatusMessage type="error" message={error} />
       </div>
     );
   }

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -3,6 +3,7 @@ import { apiClient } from '../services/api';
 import Button from '../components/ui/Button';
 import Input from '../components/ui/Input';
 import Card from '../components/ui/Card';
+import StatusMessage from '../components/StatusMessage.jsx';
 
 const TEMPLATE_TEXT = {
   books: 'Read books in your target language to expand vocabulary and comprehension.',
@@ -76,11 +77,11 @@ export default function Onboarding() {
 
   return (
     <div className="p-s">
-      <div aria-live="polite">
-        {isLoading && <p>Loading...</p>}
-        {error && <p>{error}</p>}
-      </div>
-        {step === 1 && (
+      {isLoading && (
+        <StatusMessage type="loading" message="Loading..." />
+      )}
+      {error && <StatusMessage type="error" message={error} />}
+      {step === 1 && (
         <Card>
           <h1 className="text-2xl mb-s">Choose your first goal</h1>
           <div


### PR DESCRIPTION
## Summary
- add `StatusMessage` component for unified loading and error messaging
- replace ad-hoc status `<p>` elements in onboarding, dashboard, learn screens and sidebar
- add tests for the component

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891059354f8832d8270675a386cb445