### PR TITLE
feat(frontend): surface network errors

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import StatusMessage from './StatusMessage.jsx';
+import { apiClient } from '../services/api.js';
 
 export default function Sidebar() {
   const [stats, setStats] = useState({ streak: 0, lingots: 0 });
@@ -10,9 +11,7 @@ export default function Sidebar() {
     let ignore = false;
     async function loadStats() {
       try {
-        const res = await fetch('/api/user/stats');
-        if (!res.ok) throw new Error('Failed to load');
-        const data = await res.json();
+        const data = await apiClient('/user/stats');
         if (!ignore) {
           setStats({
             streak: data.streak ?? 0,
@@ -21,7 +20,7 @@ export default function Sidebar() {
         }
       } catch (err) {
         if (!ignore) {
-          setError('Unable to load stats');
+          setError(err.message);
         }
       }
     }

--- a/frontend/src/components/Sidebar.test.jsx
+++ b/frontend/src/components/Sidebar.test.jsx
@@ -27,7 +27,10 @@ describe('Sidebar', () => {
         <Sidebar />
       </MemoryRouter>
     );
-    expect(fetch).toHaveBeenCalledWith('/api/user/stats');
+    expect(fetch).toHaveBeenCalledWith(
+      '/api/user/stats',
+      expect.objectContaining({ method: 'GET' })
+    );
     await waitFor(() => {
       expect(screen.getByText('Stats')).toBeInTheDocument();
       expect(screen.getByText('🔥 3')).toBeInTheDocument();

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -25,7 +25,7 @@ export default function Dashboard() {
         setProgress(progressData);
         setNext(nextData.next || []);
       } catch (err) {
-        setError('Unable to load dashboard data.');
+        setError(err.message);
       } finally {
         setIsLoading(false);
       }

--- a/frontend/src/screens/Dashboard.test.jsx
+++ b/frontend/src/screens/Dashboard.test.jsx
@@ -63,9 +63,7 @@ describe('Dashboard', () => {
       </MemoryRouter>
     );
     await waitFor(() => {
-      expect(
-        screen.getByText('Unable to load dashboard data.')
-      ).toBeInTheDocument();
+      expect(screen.getByText('Network request failed')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/screens/Learn.jsx
+++ b/frontend/src/screens/Learn.jsx
@@ -23,7 +23,7 @@ export default function Learn() {
         const data = await apiClient('/lesson/queue');
         setQueue(data.queue || []);
       } catch (err) {
-        setError('Unable to load lesson.');
+        setError(err.message);
       } finally {
         setIsLoading(false);
       }
@@ -41,7 +41,7 @@ export default function Learn() {
         body: { word, quality },
       });
     } catch (err) {
-      setError('Failed to submit review.');
+      setError(err.message);
     }
   };
 

--- a/frontend/src/screens/Onboarding.jsx
+++ b/frontend/src/screens/Onboarding.jsx
@@ -47,7 +47,7 @@ export default function Onboarding() {
       setSelected(result.vocab || []);
       setStep(2);
     } catch (err) {
-      setError('Failed to extract vocabulary.');
+      setError(err.message);
     } finally {
       setIsLoading(false);
     }
@@ -63,7 +63,7 @@ export default function Onboarding() {
       });
       setStep(3);
     } catch (err) {
-      setError('Failed to save goals.');
+      setError(err.message);
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -10,7 +10,12 @@ export async function apiClient(endpoint, { method = 'GET', body, headers } = {}
     ...(body ? { body: JSON.stringify(body) } : {}),
   };
 
-  const response = await fetch(`${API_BASE_URL}${endpoint}`, config);
+  let response;
+  try {
+    response = await fetch(`${API_BASE_URL}${endpoint}`, config);
+  } catch (err) {
+    throw new Error('Network request failed');
+  }
   if (!response.ok) {
     const text = await response.text();
     throw new Error(text || 'API request failed');


### PR DESCRIPTION
## Summary
- handle failed fetch calls in `apiClient`
- propagate API error messages to Dashboard, Learn, Onboarding, and Sidebar
- update tests for new error behaviour

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689107ceee0c832d942e9d45959369e7