### PR TITLE
feat: add async python runner

### DIFF
--- a/backend/services/analytics/index.ts
+++ b/backend/services/analytics/index.ts
@@ -83,7 +83,7 @@ for _ in range(5):
 print(json.dumps({'next': next_words}))
 `;
     try {
-      const result = runPython(code, [
+      const result = await runPython(code, [
         JSON.stringify(goalRanks),
         JSON.stringify(review),
         JSON.stringify(activeGoals.map((g) => g.word)),

--- a/backend/services/goal/index.ts
+++ b/backend/services/goal/index.ts
@@ -113,7 +113,7 @@ vocab=extract_vocabulary(path, manager)
 print(json.dumps({'vocab': vocab}))
 `;
     try {
-      const result = runPython(code, [JSON.stringify(goals), tempPath]);
+      const result = await runPython(code, [JSON.stringify(goals), tempPath]);
       fs.unlinkSync(tempPath);
       res.json(result);
     } catch (err: any) {

--- a/backend/services/lesson/index.ts
+++ b/backend/services/lesson/index.ts
@@ -66,11 +66,11 @@ print(json.dumps({'lesson': lesson, 'words': list(dict.fromkeys(new_words+review
 `;
     try {
       const result =
-        runPython(code, [
+        (await runPython(code, [
           JSON.stringify(goalRanks),
           JSON.stringify(activeGoals),
           JSON.stringify(review),
-        ]) || { lesson: [], words: [] };
+        ])) || { lesson: [], words: [] };
       const queue = [...(result.lesson || [])];
       const words: string[] = result.words || [];
       words.forEach((word) => {
@@ -131,7 +131,7 @@ new_state={w:{'repetitions':s.state.repetitions,'interval':s.state.interval,'efa
 print(json.dumps({'state': new_state, 'next_review': new_state[word]['next_review']}))
 `;
     try {
-      const result = runPython(code, [
+      const result = await runPython(code, [
         JSON.stringify(goalRanks),
         JSON.stringify(state),
         word,
@@ -145,7 +145,7 @@ print(json.dumps({'state': new_state, 'next_review': new_state[word]['next_revie
   });
 
   // AI-generated lesson content
-  app.get('/lesson', (req, res) => {
+  app.get('/lesson', async (req, res) => {
     const topic = (req.query.topic as string) || '';
     const code = `
 import json, sys
@@ -154,7 +154,7 @@ topic=sys.argv[1]
 print(json.dumps(generate_lesson(topic)))
 `;
     try {
-      const lesson = runPython(code, [topic]);
+      const lesson = await runPython(code, [topic]);
       res.json(lesson);
     } catch (err: any) {
       res.status(500).json({ error: err.message });

--- a/backend/services/media/index.ts
+++ b/backend/services/media/index.ts
@@ -8,7 +8,7 @@ export function createMediaService() {
 
   // ---------------------------------------------------------------------------
   // Media suggestions
-  app.get('/suggest', (req, res) => {
+  app.get('/suggest', async (req, res) => {
     const word = (req.query.word as string) || '';
     const level = Number(req.query.level || 1);
     const code = `
@@ -19,7 +19,7 @@ level=int(sys.argv[2])
 print(json.dumps(suggest_media(word, level)))
 `;
     try {
-      const media = runPython(code, [word, String(level)]);
+      const media = await runPython(code, [word, String(level)]);
       res.json(media);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -27,7 +27,7 @@ print(json.dumps(suggest_media(word, level)))
   });
 
   // Record a learner interaction with a media item
-  app.post('/interaction', (req, res) => {
+  app.post('/interaction', async (req, res) => {
     const { userId, mediaId, word } = req.body || {};
     if (!userId || !mediaId || !word) {
       return res.status(400).json({ error: 'userId, mediaId and word required' });
@@ -39,7 +39,7 @@ record_media_interaction(sys.argv[1], sys.argv[2], sys.argv[3])
 print(json.dumps({'status': 'ok'}))
 `;
     try {
-      const result = runPython(code, [userId, mediaId, word]);
+      const result = await runPython(code, [userId, mediaId, word]);
       res.json(result);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -47,7 +47,7 @@ print(json.dumps({'status': 'ok'}))
   });
 
   // AI blurb generation
-  app.post('/blurb', (req, res) => {
+  app.post('/blurb', async (req, res) => {
     const { knownWords = [], lPlusOneWords = [], length = 0 } = req.body || {};
     const code = `
 import json, sys
@@ -58,7 +58,7 @@ length=int(sys.argv[3])
 print(json.dumps({'blurb': generate_blurb(known, lplus, length)}))
 `;
     try {
-      const result = runPython(code, [
+      const result = await runPython(code, [
         JSON.stringify(knownWords),
         JSON.stringify(lPlusOneWords),
         String(length),

--- a/backend/shared/database/data.ts
+++ b/backend/shared/database/data.ts
@@ -24,7 +24,7 @@ export async function loadGoals(): Promise<{
   );
   let goals = Array.isArray(res.Item?.data) ? res.Item!.data : [];
   if (!goals.length) {
-    const result = runPython(
+    const result = await runPython(
       "import json\nfrom language_learning.goals import load_default_goals\nprint(json.dumps([g.__dict__ for g in load_default_goals()]))",
     );
     goals = result || [];
@@ -56,7 +56,7 @@ export async function saveReviewState(state: Record<string, any>) {
 
 // Load the default top 5 words from the bundled COCA list
 export async function loadDefaultCocaWords(): Promise<string[]> {
-  const result = runPython(
+  const result = await runPython(
     "import json\nfrom language_learning.goals import load_default_goals\nprint(json.dumps([g.word for g in load_default_goals()]))",
   );
   return result || [];

--- a/backend/shared/utils/python.ts
+++ b/backend/shared/utils/python.ts
@@ -1,19 +1,58 @@
-import { spawnSync } from 'child_process';
+import { spawn } from 'child_process';
 
-export function runPython(code: string, args: string[] = []) {
-  const result = spawnSync('python', ['-c', code, ...args], {
-    encoding: 'utf-8',
-    env: { ...process.env, PYTHONPATH: 'src' },
+/**
+ * Execute Python code asynchronously, resolving with parsed JSON output.
+ * Stdout and stderr are captured incrementally. The returned promise is
+ * rejected if the process exits with a non-zero code or if stderr receives
+ * content. A timeout (ms) may be provided to kill the process if it hangs.
+ */
+export function runPython(
+  code: string,
+  args: string[] = [],
+  { timeoutMs = 10000 }: { timeoutMs?: number } = {},
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('python', ['-c', code, ...args], {
+      env: { ...process.env, PYTHONPATH: 'src' },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    const timer = timeoutMs
+      ? setTimeout(() => {
+          proc.kill();
+          reject(new Error('Python process timed out'));
+        }, timeoutMs)
+      : null;
+
+    proc.stdout?.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+
+    proc.on('close', (code) => {
+      if (timer) clearTimeout(timer);
+      if (code !== 0) {
+        return reject(new Error(stderr || `Python exited with code ${code}`));
+      }
+      if (stderr.trim()) {
+        return reject(new Error(stderr));
+      }
+      try {
+        const out = stdout.trim();
+        resolve(out ? JSON.parse(out) : null);
+      } catch (err) {
+        reject(err);
+      }
+    });
   });
-  if (result.error) {
-    throw result.error;
-  }
-  if (result.stderr) {
-    const err = result.stderr.toString();
-    if (err.trim()) {
-      throw new Error(err);
-    }
-  }
-  const stdout = result.stdout.toString().trim();
-  return stdout ? JSON.parse(stdout) : null;
 }


### PR DESCRIPTION
## Summary
- add asynchronous `runPython` helper using `spawn` with timeout and streaming
- await async runner in backend services

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689112969d50832db0cfd0cb3d9dbb04