### PR TITLE
refactor: centralize goal rank building

### DIFF
--- a/backend/services/analytics/index.ts
+++ b/backend/services/analytics/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { runPython } from '../../shared/utils';
+import { runPython, buildGoalRanks } from '../../shared/utils';
 import {
   loadGoals,
   loadReviewState,
@@ -43,18 +43,7 @@ export function createAnalyticsService() {
     const goals = await loadGoals();
     const defaults = await loadDefaultCocaWords();
     const review = await loadReviewState();
-    const customGoals = goals.filter((g) => !g.is_default);
-    const activeGoals =
-      customGoals.length > 0
-        ? customGoals
-        : defaults.map((w) => ({ word: w }));
-    const goalRanks: Record<string, number> = {};
-    defaults.forEach((w, i) => {
-      goalRanks[w] = i + 1;
-    });
-    activeGoals.forEach((g, i) => {
-      goalRanks[g.word] = i + 1;
-    });
+    const { activeGoals, goalRanks } = buildGoalRanks(goals, defaults, review);
     const code = `
 import json, sys
 from datetime import datetime

--- a/backend/services/lesson/index.ts
+++ b/backend/services/lesson/index.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { runPython } from '../../shared/utils';
+import { runPython, buildGoalRanks } from '../../shared/utils';
 import {
   loadGoals,
   loadReviewState,
@@ -21,18 +21,7 @@ export function createLessonService() {
     const goals = await loadGoals();
     const defaults = await loadDefaultCocaWords();
     const review = await loadReviewState();
-    const customGoals = goals.filter((g) => !g.is_default);
-    const activeGoals =
-      customGoals.length > 0
-        ? customGoals
-        : defaults.map((w) => ({ word: w }));
-    const goalRanks: Record<string, number> = {};
-    defaults.forEach((w, i) => {
-      goalRanks[w] = i + 1;
-    });
-    activeGoals.forEach((g, i) => {
-      goalRanks[g.word] = i + 1;
-    });
+    const { activeGoals, goalRanks } = buildGoalRanks(goals, defaults, review);
     const code = `
 import json, sys
 from datetime import datetime
@@ -99,18 +88,7 @@ print(json.dumps({'lesson': lesson, 'words': list(dict.fromkeys(new_words+review
     const goals = await loadGoals();
     const defaults = await loadDefaultCocaWords();
     const state = await loadReviewState();
-    const customGoals = goals.filter((g) => !g.is_default);
-    const activeGoals =
-      customGoals.length > 0
-        ? customGoals
-        : defaults.map((w) => ({ word: w }));
-    const goalRanks: Record<string, number> = {};
-    defaults.forEach((w, i) => {
-      goalRanks[w] = i + 1;
-    });
-    activeGoals.forEach((g, i) => {
-      goalRanks[g.word] = i + 1;
-    });
+    const { goalRanks } = buildGoalRanks(goals, defaults, state);
     const code = `
 import json, sys
 from datetime import datetime

--- a/backend/shared/utils/goals.ts
+++ b/backend/shared/utils/goals.ts
@@ -1,0 +1,40 @@
+export interface Goal {
+  word: string;
+  is_default?: boolean;
+}
+
+export interface ReviewState {
+  [word: string]: any;
+}
+
+/**
+ * Build active goals and goal ranking map based on current goals,
+ * default word list, and review state.
+ *
+ * If the learner has any custom goals, those are treated as the active
+ * goal list. Otherwise we fall back to the provided default words.
+ *
+ * The returned goalRanks object maps each goal word to its rank (1-based)
+ * according to its order in the default list followed by active goals.
+ */
+export function buildGoalRanks(
+  goals: Goal[],
+  defaults: string[],
+  _review: ReviewState,
+): { activeGoals: Goal[]; goalRanks: Record<string, number> } {
+  const customGoals = goals.filter((g) => !g.is_default);
+  const activeGoals =
+    customGoals.length > 0
+      ? customGoals
+      : defaults.map((w) => ({ word: w }));
+
+  const goalRanks: Record<string, number> = {};
+  defaults.forEach((w, i) => {
+    goalRanks[w] = i + 1;
+  });
+  activeGoals.forEach((g, i) => {
+    goalRanks[g.word] = i + 1;
+  });
+
+  return { activeGoals, goalRanks };
+}

--- a/backend/shared/utils/index.ts
+++ b/backend/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './redis';
 export * from './python';
+export * from './goals';


### PR DESCRIPTION
## Summary
- add `buildGoalRanks` helper to compute active goal list and ranks
- refactor lesson and analytics services to use shared helper

## Testing
- `npm test` (fails: ENOENT package.json)
- `cd backend && npm test` (fails: Missing script "test")
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689114dde5d4832d8f4fc08cf5ba39b3