### PR TITLE
refactor: invoke Python modules

### DIFF
--- a/backend/services/goal/index.ts
+++ b/backend/services/goal/index.ts
@@ -100,20 +100,11 @@ export function createGoalService() {
     const goals = await loadGoals();
     const tempPath = path.resolve(__dirname, '../../../tmp_corpus.txt');
     fs.writeFileSync(tempPath, text, 'utf-8');
-    const code = `
-import json, sys
-from language_learning.goals import GoalManager, GoalItem
-from language_learning.vocabulary import extract_vocabulary
-goals=json.loads(sys.argv[1])
-path=sys.argv[2]
-manager=GoalManager()
-for g in goals:
-    manager.create_goal(GoalItem(g['word'], float(g.get('weight',1))))
-vocab=extract_vocabulary(path, manager)
-print(json.dumps({'vocab': vocab}))
-`;
     try {
-      const result = await runPython(code, [JSON.stringify(goals), tempPath]);
+      const result = await runPython(
+        'language_learning.entrypoints',
+        ['vocabulary', JSON.stringify(goals), tempPath],
+      );
       fs.unlinkSync(tempPath);
       res.json(result);
     } catch (err: any) {

--- a/backend/services/media/index.ts
+++ b/backend/services/media/index.ts
@@ -11,15 +11,12 @@ export function createMediaService() {
   app.get('/suggest', async (req, res) => {
     const word = (req.query.word as string) || '';
     const level = Number(req.query.level || 1);
-    const code = `
-import json, sys
-from language_learning.media_integration import suggest_media
-word=sys.argv[1]
-level=int(sys.argv[2])
-print(json.dumps(suggest_media(word, level)))
-`;
     try {
-      const media = await runPython(code, [word, String(level)]);
+      const media = await runPython('language_learning.entrypoints', [
+        'media_suggest',
+        word,
+        String(level),
+      ]);
       res.json(media);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -32,14 +29,13 @@ print(json.dumps(suggest_media(word, level)))
     if (!userId || !mediaId || !word) {
       return res.status(400).json({ error: 'userId, mediaId and word required' });
     }
-    const code = `
-import json, sys
-from language_learning.media_integration import record_media_interaction
-record_media_interaction(sys.argv[1], sys.argv[2], sys.argv[3])
-print(json.dumps({'status': 'ok'}))
-`;
     try {
-      const result = await runPython(code, [userId, mediaId, word]);
+      const result = await runPython('language_learning.entrypoints', [
+        'media_record',
+        userId,
+        mediaId,
+        word,
+      ]);
       res.json(result);
     } catch (err: any) {
       res.status(500).json({ error: err.message });
@@ -49,16 +45,9 @@ print(json.dumps({'status': 'ok'}))
   // AI blurb generation
   app.post('/blurb', async (req, res) => {
     const { knownWords = [], lPlusOneWords = [], length = 0 } = req.body || {};
-    const code = `
-import json, sys
-from language_learning.ai_blurbs import generate_blurb
-known=json.loads(sys.argv[1])
-lplus=json.loads(sys.argv[2])
-length=int(sys.argv[3])
-print(json.dumps({'blurb': generate_blurb(known, lplus, length)}))
-`;
     try {
-      const result = await runPython(code, [
+      const result = await runPython('language_learning.entrypoints', [
+        'blurb',
         JSON.stringify(knownWords),
         JSON.stringify(lPlusOneWords),
         String(length),

--- a/backend/shared/database/data.ts
+++ b/backend/shared/database/data.ts
@@ -25,7 +25,8 @@ export async function loadGoals(): Promise<{
   let goals = Array.isArray(res.Item?.data) ? res.Item!.data : [];
   if (!goals.length) {
     const result = await runPython(
-      "import json\nfrom language_learning.goals import load_default_goals\nprint(json.dumps([g.__dict__ for g in load_default_goals()]))",
+      'language_learning.entrypoints',
+      ['default_goals'],
     );
     goals = result || [];
     if (goals.length) {
@@ -57,7 +58,8 @@ export async function saveReviewState(state: Record<string, any>) {
 // Load the default top 5 words from the bundled COCA list
 export async function loadDefaultCocaWords(): Promise<string[]> {
   const result = await runPython(
-    "import json\nfrom language_learning.goals import load_default_goals\nprint(json.dumps([g.word for g in load_default_goals()]))",
+    'language_learning.entrypoints',
+    ['default_words'],
   );
   return result || [];
 }

--- a/backend/shared/utils/python.ts
+++ b/backend/shared/utils/python.ts
@@ -1,18 +1,19 @@
 import { spawn } from 'child_process';
 
 /**
- * Execute Python code asynchronously, resolving with parsed JSON output.
- * Stdout and stderr are captured incrementally. The returned promise is
- * rejected if the process exits with a non-zero code or if stderr receives
- * content. A timeout (ms) may be provided to kill the process if it hangs.
+ * Execute a Python module asynchronously via ``python -m`` and resolve with
+ * parsed JSON output. Stdout and stderr are captured incrementally. The
+ * returned promise is rejected if the process exits with a non-zero code or if
+ * stderr receives content. A timeout (ms) may be provided to kill the process
+ * if it hangs.
  */
 export function runPython(
-  code: string,
+  module: string,
   args: string[] = [],
   { timeoutMs = 10000 }: { timeoutMs?: number } = {},
 ): Promise<any> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('python', ['-c', code, ...args], {
+    const proc = spawn('python', ['-m', module, ...args], {
       env: { ...process.env, PYTHONPATH: 'src' },
     });
 

--- a/src/language_learning/entrypoints.py
+++ b/src/language_learning/entrypoints.py
@@ -1,0 +1,156 @@
+import json
+import sys
+from datetime import datetime
+
+from .goals import GoalManager, GoalItem, load_default_goals
+from .vocabulary import extract_vocabulary
+from .spaced_repetition import SRSFilter, SpacedRepetitionScheduler
+from .ai_lessons import generate_lesson, generate_mcq_lesson
+from .media_integration import suggest_media, record_media_interaction
+from .ai_blurbs import generate_blurb
+
+
+def vocabulary(goals_json: str, corpus_path: str) -> None:
+    goals = json.loads(goals_json)
+    manager = GoalManager()
+    for g in goals:
+        manager.create_goal(GoalItem(g["word"], float(g.get("weight", 1))))
+    vocab = extract_vocabulary(corpus_path, manager)
+    print(json.dumps({"vocab": vocab}))
+
+
+def lesson_queue(goal_ranks_json: str, goals_json: str, review_json: str) -> None:
+    goal_ranks = json.loads(goal_ranks_json)
+    goals = json.loads(goals_json)
+    review = json.loads(review_json)
+    visible_words = {g["word"] for g in goals}
+    filt = SRSFilter(goal_ranks)
+    for word, info in review.items():
+        st = filt.schedulers.setdefault(word, SpacedRepetitionScheduler()).state
+        st.repetitions = int(info.get("repetitions", 0))
+        st.interval = int(info.get("interval", 0))
+        st.efactor = float(info.get("efactor", 2.5))
+        st.next_review = datetime.fromisoformat(info["next_review"])
+    review_words: list[str] = []
+    while True:
+        nxt = filt.pop_next_due()
+        if not nxt:
+            break
+        if visible_words and nxt not in visible_words:
+            del filt.schedulers[nxt]
+            continue
+        review_words.append(nxt)
+        del filt.schedulers[nxt]
+    new_words = [
+        g["word"]
+        for g in goals
+        if g["word"] not in review or review[g["word"]].get("repetitions", 0) == 0
+    ]
+    new_words = [w for w in new_words if w not in review_words][:3]
+    lesson = generate_mcq_lesson("practice", new_words, review_words)
+    print(json.dumps({"lesson": lesson, "words": list(dict.fromkeys(new_words + review_words))}))
+
+
+def review(goal_ranks_json: str, state_json: str, word: str, quality_str: str) -> None:
+    goal_ranks = json.loads(goal_ranks_json)
+    state = json.loads(state_json)
+    quality = int(quality_str)
+    filt = SRSFilter(goal_ranks)
+    for w, info in state.items():
+        st = filt.schedulers.setdefault(w, SpacedRepetitionScheduler()).state
+        st.repetitions = int(info.get("repetitions", 0))
+        st.interval = int(info.get("interval", 0))
+        st.efactor = float(info.get("efactor", 2.5))
+        st.next_review = datetime.fromisoformat(info["next_review"])
+    filt.review(word, quality)
+    new_state = {
+        w: {
+            "repetitions": s.state.repetitions,
+            "interval": s.state.interval,
+            "efactor": s.state.efactor,
+            "next_review": s.state.next_review.isoformat(),
+        }
+        for w, s in filt.schedulers.items()
+    }
+    print(json.dumps({"state": new_state, "next_review": new_state[word]["next_review"]}))
+
+
+def lesson(topic: str) -> None:
+    print(json.dumps(generate_lesson(topic)))
+
+
+def default_goals() -> None:
+    print(json.dumps([g.__dict__ for g in load_default_goals()]))
+
+
+def default_words() -> None:
+    print(json.dumps([g.word for g in load_default_goals()]))
+
+
+def media_suggest(word: str, level_str: str) -> None:
+    level = int(level_str)
+    print(json.dumps(suggest_media(word, level)))
+
+
+def media_record(user_id: str, media_id: str, word: str) -> None:
+    record_media_interaction(user_id, media_id, word)
+    print(json.dumps({"status": "ok"}))
+
+
+def blurb(known_json: str, lplus_json: str, length_str: str) -> None:
+    known = json.loads(known_json)
+    lplus = json.loads(lplus_json)
+    length = int(length_str)
+    print(json.dumps({"blurb": generate_blurb(known, lplus, length)}))
+
+
+def analytics_next(goal_ranks_json: str, review_json: str, visible_json: str) -> None:
+    goal_ranks = json.loads(goal_ranks_json)
+    review = json.loads(review_json)
+    visible = set(json.loads(visible_json))
+    filt = SRSFilter(goal_ranks)
+    for word, info in review.items():
+        st = filt.schedulers.setdefault(word, SpacedRepetitionScheduler()).state
+        st.repetitions = int(info.get("repetitions", 0))
+        st.interval = int(info.get("interval", 0))
+        st.efactor = float(info.get("efactor", 2.5))
+        st.next_review = datetime.fromisoformat(info["next_review"])
+    next_words: list[str] = []
+    for _ in range(5):
+        nxt = filt.pop_next_due()
+        if not nxt:
+            break
+        if visible and nxt not in visible:
+            del filt.schedulers[nxt]
+            continue
+        next_words.append(nxt)
+        del filt.schedulers[nxt]
+    print(json.dumps({"next": next_words}))
+
+
+COMMANDS = {
+    "vocabulary": vocabulary,
+    "lesson_queue": lesson_queue,
+    "review": review,
+    "lesson": lesson,
+    "default_goals": default_goals,
+    "default_words": default_words,
+    "media_suggest": media_suggest,
+    "media_record": media_record,
+    "blurb": blurb,
+    "analytics_next": analytics_next,
+}
+
+
+def main(argv: list[str] | None = None) -> None:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        raise SystemExit("No command provided")
+    cmd = argv.pop(0)
+    if cmd not in COMMANDS:
+        raise SystemExit(f"Unknown command: {cmd}")
+    COMMANDS[cmd](*argv)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `language_learning.entrypoints` module exposing reusable CLI helpers
- refactor backend utilities to run Python modules instead of code strings
- update backend services to invoke the new entrypoints

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689115e3e798832d8401c4065271a3d8