### PR TITLE
Add JSONStorage backup and error handling

### DIFF
--- a/src/language_learning/storage.py
+++ b/src/language_learning/storage.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 from dataclasses import asdict
 from typing import Any, Dict, List, Optional
 
@@ -27,10 +28,22 @@ class JSONStorage:
     def _read(self) -> Dict[str, Any]:
         if not os.path.exists(self.path):
             return {}
-        with open(self.path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
+        try:
+            with open(self.path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError:
+            backup = f"{self.path}.bak"
+            if os.path.exists(backup):
+                try:
+                    with open(backup, "r", encoding="utf-8") as fh:
+                        return json.load(fh)
+                except json.JSONDecodeError:
+                    pass
+            return {}
 
     def _write(self, data: Dict[str, Any]) -> None:
+        if os.path.exists(self.path):
+            shutil.copy(self.path, f"{self.path}.bak")
         with open(self.path, "w", encoding="utf-8") as fh:
             json.dump(data, fh)
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,25 @@
+import os
+from language_learning.storage import JSONStorage
+
+
+def test_read_corrupt_json_returns_empty(tmp_path):
+    path = tmp_path / "store.json"
+    path.write_text("{not valid}", encoding="utf-8")
+    store = JSONStorage(path)
+    assert store.load_user() is None
+    assert store.load_goals() == []
+    assert store.load_review_state() == {}
+
+
+def test_read_uses_backup_on_decode_error(tmp_path):
+    store = JSONStorage(tmp_path / "store.json")
+    store.save_user({"name": "Alice"})
+    store.save_user({"name": "Bob"})
+    # At this point a backup containing the first user should exist
+    backup_path = f"{store.path}.bak"
+    assert os.path.exists(backup_path)
+    # Corrupt the main file
+    with open(store.path, "w", encoding="utf-8") as fh:
+        fh.write("{invalid}")
+    user = store.load_user()
+    assert user == {"name": "Alice"}


### PR DESCRIPTION
## Summary
- handle `json.JSONDecodeError` in `JSONStorage._read` and attempt to load a `.bak` file or return an empty dict
- create a `.bak` file before overwriting storage to avoid data loss
- test corrupted storage recovery and backup fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891187e8da0832da26003cc1f1f0e01