### PR TITLE
feat: add focus glow style to Input

### DIFF
--- a/frontend/src/components/ui/Input.jsx
+++ b/frontend/src/components/ui/Input.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 export default function Input({ as = 'input', className = '', ...props }) {
   const Component = as;
-  const base = 'border rounded p-xs focus:outline focus:outline-2 focus:outline-offset-2';
+  const base =
+    'border rounded p-xs focus:outline focus:outline-2 focus:outline-offset-2 focus:shadow-[0_0_0_3px_rgba(255,191,50,0.3)]';
   return <Component className={`${base} ${className}`} {...props} />;
 }


### PR DESCRIPTION
## Summary
- add focus shadow ring to Input to match focus glow

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68911d24fb24832dbb8569571a1000e0