### PR TITLE
style: toggle header icon color with active state

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -58,7 +58,7 @@ export default function Layout({ children }) {
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="w-6 h-6"
+            className={`w-6 h-6 ${settingsOpen ? 'text-accent' : 'text-text-secondary'}`}
           >
             <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.088c1.543.94 1.031 3.28-.772 3.58a1.724 1.724 0 000 3.03c1.803.3 2.315 2.64.772 3.58a1.724 1.724 0 00-2.573 1.089c-.426 1.755-2.924 1.755-3.35 0a1.724 1.724 0 00-2.573-1.09c-1.543-.939-1.031-3.279.772-3.579a1.724 1.724 0 000-3.031c-1.803-.3-2.315-2.64-.772-3.58a1.724 1.724 0 002.573-1.088z" />
             <circle cx="12" cy="12" r="3" />

--- a/frontend/src/components/Layout.test.jsx
+++ b/frontend/src/components/Layout.test.jsx
@@ -1,8 +1,9 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as matchers from '@testing-library/jest-dom/matchers';
 import Layout from './Layout.jsx';
+import { ThemeProvider } from '../context/ThemeContext.jsx';
 
 expect.extend(matchers);
 
@@ -14,6 +15,11 @@ describe('Layout', () => {
         json: () => Promise.resolve({ streak: 0, lingots: 0 })
       })
     ));
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }));
   });
 
   afterEach(() => {
@@ -24,10 +30,30 @@ describe('Layout', () => {
   test('renders the logo in the header', () => {
     render(
       <MemoryRouter>
-        <Layout>Child</Layout>
+        <ThemeProvider>
+          <Layout>Child</Layout>
+        </ThemeProvider>
       </MemoryRouter>
     );
     const logo = screen.getByAltText(/fluent milestones logo/i);
     expect(logo).toBeInTheDocument();
+  });
+
+  test('settings icon updates color when active', () => {
+    render(
+      <MemoryRouter>
+        <ThemeProvider>
+          <Layout>Child</Layout>
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+    const settingsButton = screen.getByLabelText(/open settings/i);
+    const icon = settingsButton.querySelector('svg');
+    expect(icon).toHaveClass('text-text-secondary');
+
+    fireEvent.click(settingsButton);
+
+    const updatedIcon = settingsButton.querySelector('svg');
+    expect(updatedIcon).toHaveClass('text-accent');
   });
 });


### PR DESCRIPTION
## Summary
- use `text-accent` and `text-text-secondary` to color the settings icon in `Layout`
- add a test ensuring the settings icon updates color when opened

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891298bb9d0832db458ab21329ddf4b