### PR TITLE
fix: emit frontend bundles under js directory

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -3,6 +3,21 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  build: {
+    assetsDir: 'js',
+    rollupOptions: {
+      output: {
+        entryFileNames: 'js/[name]-[hash].js',
+        chunkFileNames: 'js/[name]-[hash].js',
+        assetFileNames: ({ name }) => {
+          if (name && name.endsWith('.css')) {
+            return 'css/[name]-[hash][extname]';
+          }
+          return 'js/[name]-[hash][extname]';
+        },
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- ensure Vite outputs JS chunks into `/js` and CSS into `/css`

## Testing
- `npm run build`
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912aae4ee4832db97308582dc56547