### PR TITLE
Use UUIDs for user records

### DIFF
--- a/backend/services/auth/index.ts
+++ b/backend/services/auth/index.ts
@@ -48,7 +48,7 @@ export function createAuthService() {
   });
 
   app.put('/users/:id', async (req, res) => {
-    const id = Number(req.params.id);
+    const { id } = req.params;
     const { username, password } = req.body as {
       username?: string;
       password?: string;
@@ -64,7 +64,7 @@ export function createAuthService() {
   });
 
   app.delete('/users/:id', async (req, res) => {
-    const id = Number(req.params.id);
+    const { id } = req.params;
     const user = await getUserById(id);
     if (!user) {
       return res.status(404).json({ error: 'user not found' });

--- a/backend/shared/database/data.ts
+++ b/backend/shared/database/data.ts
@@ -6,6 +6,7 @@ import {
   ScanCommand,
   DeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
+import { randomUUID } from 'crypto';
 import { runPython } from '../utils';
 
 const TABLE_NAME = process.env.DATA_TABLE || 'language-learning-data';
@@ -67,7 +68,7 @@ export async function loadDefaultCocaWords(): Promise<string[]> {
 const USERS_PREFIX = 'user#';
 
 export type UserRecord = {
-  id: number;
+  id: string;
   username: string;
   passwordHash: string;
 };
@@ -76,7 +77,7 @@ export async function createUser(
   username: string,
   passwordHash: string,
 ): Promise<UserRecord> {
-  const id = Date.now();
+  const id = randomUUID();
   const user: UserRecord = { id, username, passwordHash };
   await dynamo.send(
     new PutCommand({
@@ -87,7 +88,7 @@ export async function createUser(
   return user;
 }
 
-export async function getUserById(id: number): Promise<UserRecord | null> {
+export async function getUserById(id: string): Promise<UserRecord | null> {
   const res = await dynamo.send(
     new GetCommand({ TableName: TABLE_NAME, Key: { pk: `${USERS_PREFIX}${id}` } }),
   );
@@ -137,7 +138,7 @@ export async function saveUser(user: UserRecord) {
   );
 }
 
-export async function deleteUser(id: number) {
+export async function deleteUser(id: string) {
   await dynamo.send(
     new DeleteCommand({ TableName: TABLE_NAME, Key: { pk: `${USERS_PREFIX}${id}` } }),
   );


### PR DESCRIPTION
## Summary
- switch user IDs from timestamps to crypto UUIDs
- adjust user DB helpers and auth service to accept string IDs

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68912f5fb534832d83b9bcc27c41c145