### PR TITLE
Use absolute PYTHONPATH for Python runner

### DIFF
--- a/backend/shared/utils/python.ts
+++ b/backend/shared/utils/python.ts
@@ -1,4 +1,7 @@
 import { spawn } from 'child_process';
+import path from 'path';
+
+const pyPath = path.resolve(__dirname, '../../../src');
 
 /**
  * Execute a Python module asynchronously via ``python -m`` and resolve with
@@ -14,7 +17,7 @@ export function runPython(
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     const proc = spawn('python', ['-m', module, ...args], {
-      env: { ...process.env, PYTHONPATH: 'src' },
+      env: { ...process.env, PYTHONPATH: pyPath },
     });
 
     let stdout = '';


### PR DESCRIPTION
## Summary
- Resolve the project’s Python path using Node’s `path` module
- Ensure spawned Python processes receive the absolute `PYTHONPATH`

## Testing
- `npm --prefix backend run build`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891320b9a24832d9ead066fb5d8d7c5