### PR TITLE
Add web app manifest

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,16 @@
+{
+  "short_name": "LanguageLearning",
+  "name": "Language Learning",
+  "description": "Demo manifest for offline UI assets",
+  "icons": [
+    {
+      "src": "/favicon.ico",
+      "sizes": "16x16",
+      "type": "image/x-icon"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff"
+}


### PR DESCRIPTION
## Summary
- add web application manifest for language learning front-end

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68915de8a06c832dbb337d9dd2b5083c