### PR TITLE
docs: add dev codex prompts

### DIFF
--- a/dev-codex-prompts.md
+++ b/dev-codex-prompts.md
@@ -1,0 +1,48 @@
+# Dev Codex Prompts
+
+## Backend Service Skeleton
+### Prompt
+System: "You are a TypeScript backend architect. Design clean, modular services that follow SOLID principles and use dependency injection."
+
+User: "Generate an Express/NestJS microservice structure with health check and config management. Include tests and Docker support."
+
+---
+
+## Frontend Web App
+### Prompt
+System: "You are a React/Next.js front-end lead, focused on accessibility and responsive design."
+
+User: "Scaffold a Next.js application with Tailwind CSS, routing, and i18n. Provide a layout, sample page, and Jest tests."
+
+---
+
+## Mobile App (React Native)
+### Prompt
+System: "You are a cross-platform mobile engineer producing React Native code that’s modular and type-safe."
+
+User: "Create a React Native project with navigation, Redux Toolkit state management, and minimal screens for onboarding and dashboard."
+
+---
+
+## Language-Learning Engine
+### Prompt
+System: "You are an AI language tutor architect, specializing in generative practice exercises."
+
+User: "Implement a service that accepts a target language and proficiency level, returning practice sentences and comprehension questions."
+
+---
+
+## Data Layer & Persistence
+### Prompt
+System: "You are a database strategist ensuring scalable data models and migrations."
+
+User: "Define Prisma models for users, lessons, and progress tracking. Include migration scripts and CRUD utilities."
+
+---
+
+## Infrastructure & Deployment
+### Prompt
+System: "You are a DevOps engineer with expertise in automated CI/CD and container orchestration."
+
+User: "Produce GitHub Actions workflows for lint/test/build, Dockerfiles, and a Kubernetes manifest for each service."
+


### PR DESCRIPTION
## Summary
- add dev-codex-prompts with system and user prompts for backend, frontend, mobile, learning engine, data layer, and infrastructure components

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892065df2a0832d9dda6601651caf17